### PR TITLE
Add end-to-end test suite for live stack

### DIFF
--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Run the end-to-end test suite against a live Docker Compose stack.
+#
+# Usage:
+#   ./scripts/run-e2e.sh [--keep-up] [extra pytest args...]
+#
+# Options:
+#   --keep-up     Don't docker compose down after tests (useful during dev)
+#
+# Environment:
+#   E2E_API_KEY   Set to a key from PLATFORM_API_KEYS to test auth enforcement.
+#                 Leave empty when PLATFORM_API_KEYS is not set (dev mode).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+KEEP_UP=false
+PYTEST_ARGS=()
+for arg in "$@"; do
+  if [[ "$arg" == "--keep-up" ]]; then
+    KEEP_UP=true
+  else
+    PYTEST_ARGS+=("$arg")
+  fi
+done
+
+# ── Compose command detection ────────────────────────────────────────────────
+if command -v docker &>/dev/null && docker compose version &>/dev/null 2>&1; then
+  COMPOSE="docker compose"
+elif command -v docker-compose &>/dev/null; then
+  COMPOSE="docker-compose"
+else
+  echo "ERROR: docker compose or docker-compose not found." >&2
+  exit 1
+fi
+
+# ── Start stack if not already running ───────────────────────────────────────
+cd "$ROOT"
+echo "==> Starting services..."
+$COMPOSE up -d --build surrealdb minio minio-init agent-knowledge agent-dashboard
+
+# ── Wait for agent-knowledge ─────────────────────────────────────────────────
+echo "==> Waiting for agent-knowledge..."
+for i in $(seq 1 30); do
+  if curl -sf "http://localhost:${AGENT_KNOWLEDGE_PORT:-8001}/health" >/dev/null 2>&1; then
+    echo "    agent-knowledge is up"
+    break
+  fi
+  if [[ $i -eq 30 ]]; then
+    echo "ERROR: agent-knowledge did not start in time." >&2
+    $COMPOSE logs agent-knowledge | tail -30
+    exit 1
+  fi
+  sleep 2
+done
+
+# ── Wait for agent-dashboard ─────────────────────────────────────────────────
+echo "==> Waiting for agent-dashboard..."
+for i in $(seq 1 20); do
+  if curl -sf "http://localhost:${AGENT_DASHBOARD_PORT:-3000}/health" >/dev/null 2>&1; then
+    echo "    agent-dashboard is up"
+    break
+  fi
+  sleep 2
+done
+
+# ── Install e2e deps if needed ────────────────────────────────────────────────
+if ! python -c "import httpx, pytest" 2>/dev/null; then
+  echo "==> Installing e2e test dependencies..."
+  pip install -q -r "${ROOT}/tests/e2e/requirements.txt"
+fi
+
+# ── Run tests ─────────────────────────────────────────────────────────────────
+echo "==> Running e2e tests..."
+cd "${ROOT}/tests/e2e"
+python -m pytest . -v "${PYTEST_ARGS[@]+"${PYTEST_ARGS[@]}"}"
+E2E_EXIT=$?
+
+# ── Tear down (unless --keep-up) ─────────────────────────────────────────────
+if [[ "$KEEP_UP" == false ]]; then
+  echo "==> Stopping services..."
+  cd "$ROOT"
+  $COMPOSE down
+fi
+
+exit $E2E_EXIT

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,71 @@
+"""
+Shared fixtures for e2e tests.
+
+Set these env vars before running:
+  E2E_API_URL      - base URL for agent-knowledge  (default: http://localhost:8001)
+  E2E_DASHBOARD_URL - base URL for agent-dashboard (default: http://localhost:3000)
+  E2E_API_KEY      - API key matching PLATFORM_API_KEYS  (default: empty = auth disabled)
+"""
+import os
+import pytest
+import pytest_asyncio
+import httpx
+
+API_BASE = os.getenv("E2E_API_URL", "http://localhost:8001")
+DASHBOARD_BASE = os.getenv("E2E_DASHBOARD_URL", "http://localhost:3000")
+API_KEY = os.getenv("E2E_API_KEY", "")
+
+
+def auth_headers() -> dict:
+    h = {}
+    if API_KEY:
+        h["X-API-Key"] = API_KEY
+    return h
+
+
+def bare_id(full_id: str) -> str:
+    """Strip SurrealDB table prefix: 'agents:abc123' → 'abc123'."""
+    return full_id.split(":", 1)[1] if ":" in full_id else full_id
+
+
+@pytest_asyncio.fixture(scope="module")
+async def api():
+    """Async HTTP client aimed at agent-knowledge. Skips module if unreachable."""
+    try:
+        async with httpx.AsyncClient(base_url=API_BASE, timeout=5) as probe:
+            await probe.get("/health")
+    except (httpx.ConnectError, httpx.TimeoutException):
+        pytest.skip(f"agent-knowledge not reachable at {API_BASE} — run ./scripts/dev.sh first")
+
+    async with httpx.AsyncClient(
+        base_url=API_BASE,
+        headers=auth_headers(),
+        timeout=15,
+    ) as client:
+        yield client
+
+
+@pytest_asyncio.fixture(scope="module")
+async def api_no_auth():
+    """Client without auth headers — used to verify 401 behaviour."""
+    try:
+        async with httpx.AsyncClient(base_url=API_BASE, timeout=5) as probe:
+            await probe.get("/health")
+    except (httpx.ConnectError, httpx.TimeoutException):
+        pytest.skip(f"agent-knowledge not reachable at {API_BASE}")
+
+    async with httpx.AsyncClient(base_url=API_BASE, timeout=15) as client:
+        yield client
+
+
+@pytest_asyncio.fixture(scope="module")
+async def dashboard():
+    """Async HTTP client aimed at agent-dashboard. Skips module if unreachable."""
+    try:
+        async with httpx.AsyncClient(base_url=DASHBOARD_BASE, timeout=5) as probe:
+            await probe.get("/health")
+    except (httpx.ConnectError, httpx.TimeoutException):
+        pytest.skip(f"agent-dashboard not reachable at {DASHBOARD_BASE} — run ./scripts/dev.sh first")
+
+    async with httpx.AsyncClient(base_url=DASHBOARD_BASE, timeout=15) as client:
+        yield client

--- a/tests/e2e/pytest.ini
+++ b/tests/e2e/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = .

--- a/tests/e2e/requirements.txt
+++ b/tests/e2e/requirements.txt
@@ -1,0 +1,4 @@
+httpx>=0.27.0
+pytest>=8.0.0
+pytest-asyncio>=0.23.0
+anyio[trio]>=4.0.0

--- a/tests/e2e/test_auth.py
+++ b/tests/e2e/test_auth.py
@@ -1,0 +1,52 @@
+"""E2E: API key authentication.
+
+These tests only run meaningfully when E2E_API_KEY is set AND the server has
+PLATFORM_API_KEYS configured.  They are skipped automatically when auth is
+disabled (empty PLATFORM_API_KEYS means dev-mode pass-through).
+"""
+import os
+import pytest
+import httpx
+
+from conftest import API_BASE, API_KEY
+
+pytestmark = pytest.mark.asyncio
+
+_AUTH_ROUTE = "/agents/run/nonexistent-run"
+
+
+def _requires_auth_configured():
+    if not API_KEY:
+        pytest.skip("E2E_API_KEY not set — auth enforcement tests require PLATFORM_API_KEYS on the server")
+
+
+async def test_missing_key_returns_401(api_no_auth):
+    _requires_auth_configured()
+    r = await api_no_auth.get(_AUTH_ROUTE)
+    assert r.status_code == 401, (
+        f"Expected 401 without API key, got {r.status_code}. "
+        "Is PLATFORM_API_KEYS set on the server?"
+    )
+
+
+async def test_invalid_key_returns_401(api_no_auth):
+    _requires_auth_configured()
+    r = await api_no_auth.get(_AUTH_ROUTE, headers={"X-API-Key": "wrong-key-xyz"})
+    assert r.status_code == 401
+
+
+async def test_valid_key_does_not_return_401(api):
+    _requires_auth_configured()
+    r = await api.get(_AUTH_ROUTE)
+    assert r.status_code != 401, f"Valid API key still returned 401: {r.text}"
+
+
+async def test_cors_preflight_responds(api_no_auth):
+    r = await api_no_auth.options(
+        "/health",
+        headers={
+            "Origin": "https://example.com",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert r.status_code in (200, 204), f"CORS preflight failed: {r.status_code}"

--- a/tests/e2e/test_full_workflow.py
+++ b/tests/e2e/test_full_workflow.py
@@ -1,0 +1,191 @@
+"""E2E: complete agent workflow happy-path.
+
+Scenario (all steps run against the live stack in order):
+  1.  Create objective
+  2.  List objectives (verify it appears)
+  3.  Fetch objective by ID
+  4.  Mark objective as running
+  5.  Create workflow run
+  6.  Create researcher agent
+  7.  Create writer agent
+  8.  List agents for the run
+  9.  Create task for researcher
+  10. Complete the task
+  11. Handoff researcher → writer
+  12. Create artifact
+  13. List artifacts (verify it appears)
+  14. Evaluate artifact with CLEAR scores
+  15. Fetch eval result
+  16. Record provenance (5 evidence links → high trust score)
+  17. Fetch trust score
+  18. Trust gate (should pass at default 0.65 threshold)
+"""
+import pytest
+
+from conftest import bare_id
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_full_agent_workflow(api):
+    # ── 1. Create objective ───────────────────────────────────────────────────
+    r = await api.post("/objectives", json={
+        "title": "E2E research report on LLM benchmarks",
+        "objective_type": "research",
+        "payload": {"topic": "LLM benchmarks 2025"},
+    })
+    assert r.status_code == 200, f"create objective: {r.text}"
+    obj = r.json()
+    assert obj["title"] == "E2E research report on LLM benchmarks"
+    assert obj["status"] == "pending"
+    obj_id = obj["id"]
+    bare_obj = bare_id(obj_id)
+
+    # ── 2. List objectives ────────────────────────────────────────────────────
+    r = await api.get("/objectives")
+    assert r.status_code == 200
+    ids = [o["id"] for o in r.json()]
+    assert obj_id in ids
+
+    # ── 3. Get objective by ID ────────────────────────────────────────────────
+    r = await api.get(f"/objectives/{bare_obj}")
+    assert r.status_code == 200
+    assert r.json()["id"] == obj_id
+
+    # ── 4. Mark objective running ─────────────────────────────────────────────
+    r = await api.post(f"/objectives/{bare_obj}/run")
+    assert r.status_code == 200
+    assert r.json()["status"] == "running"
+
+    # ── 5. Create workflow run ────────────────────────────────────────────────
+    r = await api.post("/workflows/runs", json={
+        "objective_id": obj_id,
+        "initial_state": {"phase": "research"},
+    })
+    assert r.status_code == 200, f"create run: {r.text}"
+    run = r.json()
+    assert run["status"] == "running"
+    run_id = run["id"]
+    bare_run = bare_id(run_id)
+
+    # ── 6. Create researcher agent ────────────────────────────────────────────
+    r = await api.post("/agents", json={"run_id": run_id, "agent_role": "researcher"})
+    assert r.status_code == 200, f"create researcher: {r.text}"
+    researcher = r.json()
+    researcher_id = researcher["id"]
+    bare_researcher = bare_id(researcher_id)
+
+    # ── 7. Create writer agent ────────────────────────────────────────────────
+    r = await api.post("/agents", json={"run_id": run_id, "agent_role": "writer"})
+    assert r.status_code == 200, f"create writer: {r.text}"
+    writer = r.json()
+    writer_id = writer["id"]
+    bare_writer = bare_id(writer_id)
+
+    # ── 8. List agents for run ────────────────────────────────────────────────
+    r = await api.get(f"/agents/run/{bare_run}")
+    assert r.status_code == 200
+    roles = [a["agent_role"] for a in r.json()]
+    assert "researcher" in roles
+    assert "writer" in roles
+
+    # ── 9. Create task for researcher ─────────────────────────────────────────
+    r = await api.post(f"/agents/{bare_researcher}/tasks", json={
+        "description": "Gather top LLM benchmark papers from 2025",
+        "skill_id": "web_search",
+    })
+    assert r.status_code == 200, f"create task: {r.text}"
+    task = r.json()
+    task_id = task["id"]
+    bare_task = bare_id(task_id)
+    assert task["status"] == "pending"
+
+    # ── 10. Complete the task ─────────────────────────────────────────────────
+    r = await api.patch(f"/agents/{bare_researcher}/tasks/{bare_task}/complete", json={
+        "output_ref": "minio://agent-artifacts/e2e/research-notes.json",
+        "status": "completed",
+    })
+    assert r.status_code == 200, f"complete task: {r.text}"
+    assert r.json()["status"] == "completed"
+
+    # ── 11. Handoff researcher → writer ───────────────────────────────────────
+    r = await api.post(f"/agents/{bare_researcher}/handoff", json={
+        "target_agent_id": bare_writer,
+        "context": "Research complete — please draft the report",
+        "payload": {"notes_ref": "minio://agent-artifacts/e2e/research-notes.json"},
+    })
+    assert r.status_code == 200, f"handoff: {r.text}"
+
+    # ── 12. Create artifact ───────────────────────────────────────────────────
+    r = await api.post("/artifacts", json={
+        "objective_id": obj_id,
+        "artifact_type": "report",
+        "title": "LLM Benchmarks Report 2025",
+        "content_ref": "minio://agent-artifacts/e2e/report-v1.md",
+        "payload": {"word_count": 2400},
+    })
+    assert r.status_code == 200, f"create artifact: {r.text}"
+    artifact = r.json()
+    artifact_id = artifact["id"]
+    bare_artifact = bare_id(artifact_id)
+    assert artifact["status"] == "draft"
+
+    # ── 13. List artifacts ────────────────────────────────────────────────────
+    r = await api.get("/artifacts", params={"objective_id": obj_id})
+    assert r.status_code == 200
+    assert any(a["id"] == artifact_id for a in r.json())
+
+    # ── 14. Evaluate artifact (all CLEAR scores = 0.85 → passes 0.70 gate) ───
+    r = await api.post("/eval/evaluate", json={
+        "artifact_id": artifact_id,
+        "dimension_scores": {
+            "completeness": 0.85,
+            "logical": 0.90,
+            "evidence": 0.80,
+            "accuracy": 0.88,
+            "relevance": 0.92,
+        },
+        "rationale": "Thorough and well-cited report",
+        "threshold": 0.70,
+    })
+    assert r.status_code == 200, f"evaluate: {r.text}"
+    ev = r.json()
+    assert ev["passed"] is True
+    assert ev["composite_score"] >= 0.70
+
+    # ── 15. Fetch eval result ─────────────────────────────────────────────────
+    r = await api.get(f"/eval/artifacts/{artifact_id}")
+    assert r.status_code == 200
+    assert r.json()["artifact_id"] == artifact_id
+
+    # ── 16. Record provenance (5 links → trust score > 0.65) ─────────────────
+    r = await api.post("/trust/provenance", json={
+        "artifact_id": artifact_id,
+        "evidence_links": [
+            {"source_ref": "arxiv.org/abs/2501.00001", "extract": "MMLU results table", "step_description": "benchmark data"},
+            {"source_ref": "arxiv.org/abs/2501.00002", "extract": "HumanEval scores", "step_description": "coding benchmarks"},
+            {"source_ref": "openai.com/research/gpt5", "extract": "Safety evaluation", "step_description": "safety scores"},
+            {"source_ref": "anthropic.com/research/claude4", "extract": "MATH benchmark", "step_description": "math capability"},
+            {"source_ref": "huggingface.co/open-llm-leaderboard", "extract": "Leaderboard snapshot", "step_description": "rankings"},
+        ],
+    })
+    assert r.status_code == 200, f"provenance: {r.text}"
+    trust = r.json()
+    assert trust["score"] > 0.0
+
+    # ── 17. Fetch trust score ─────────────────────────────────────────────────
+    r = await api.get(f"/trust/artifacts/{artifact_id}")
+    assert r.status_code == 200
+    score_record = r.json()
+    assert score_record["artifact_id"] == artifact_id
+    assert 0.0 <= score_record["score"] <= 1.0
+
+    # ── 18. Trust gate ────────────────────────────────────────────────────────
+    r = await api.post("/trust/gate", json={
+        "artifact_id": artifact_id,
+        "threshold": 0.50,
+    })
+    assert r.status_code == 200
+    gate = r.json()
+    assert "passed" in gate
+    assert gate["score"] is not None

--- a/tests/e2e/test_health.py
+++ b/tests/e2e/test_health.py
@@ -1,0 +1,44 @@
+"""E2E: health and root endpoints."""
+import pytest
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_knowledge_health(api):
+    r = await api.get("/health")
+    assert r.status_code in (200, 503), r.text
+    body = r.json()
+    assert body["service"] == "agent-knowledge"
+    assert body["surrealdb"] in ("connected", "unreachable")
+
+
+async def test_knowledge_health_ok_when_db_connected(api):
+    r = await api.get("/health")
+    body = r.json()
+    if body["surrealdb"] == "connected":
+        assert r.status_code == 200
+        assert body["status"] == "ok"
+    else:
+        pytest.skip("SurrealDB not connected — skipping ok-status assertion")
+
+
+async def test_root_lists_routes(api):
+    r = await api.get("/")
+    assert r.status_code == 200
+    body = r.json()
+    assert "routes" in body
+    for expected in ("/agents", "/workflows", "/objectives", "/artifacts"):
+        assert expected in body["routes"]
+
+
+async def test_request_id_header(api):
+    r = await api.get("/health")
+    assert "x-request-id" in r.headers, "RequestLoggingMiddleware should add X-Request-Id"
+
+
+async def test_dashboard_health(dashboard):
+    r = await dashboard.get("/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body.get("status") == "ok"

--- a/tests/e2e/test_model_router.py
+++ b/tests/e2e/test_model_router.py
@@ -1,0 +1,98 @@
+"""E2E: model routing rules and FinOps usage tracking."""
+import uuid
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+_TASK_TYPE = f"e2e-summarise-{uuid.uuid4().hex[:8]}"
+
+
+async def test_upsert_and_get_routing_rule(api):
+    r = await api.put("/model-router/rules", json={
+        "task_type": _TASK_TYPE,
+        "preferred_provider": "anthropic",
+        "models": [
+            {"model_id": "claude-haiku-4-5", "provider": "anthropic", "priority": 1, "max_cost_per_call": 0.002},
+            {"model_id": "claude-sonnet-4-6", "provider": "anthropic", "priority": 2, "max_cost_per_call": 0.015},
+        ],
+        "max_cost_per_call": 0.015,
+        "daily_budget": 5.0,
+        "enabled": True,
+    })
+    assert r.status_code == 200, r.text
+    rule = r.json()
+    assert rule["task_type"] == _TASK_TYPE
+    assert rule["enabled"] is True
+
+    # Fetch by task_type
+    r = await api.get(f"/model-router/rules/{_TASK_TYPE}")
+    assert r.status_code == 200
+    assert r.json()["task_type"] == _TASK_TYPE
+
+
+async def test_list_routing_rules_contains_upserted(api):
+    r = await api.get("/model-router/rules")
+    assert r.status_code == 200
+    types = [rule["task_type"] for rule in r.json()]
+    assert _TASK_TYPE in types
+
+
+async def test_model_selection_returns_candidate(api):
+    r = await api.post("/model-router/select", json={"task_type": _TASK_TYPE})
+    assert r.status_code == 200, r.text
+    sel = r.json()
+    assert "model_id" in sel
+    assert "provider" in sel
+    assert "rationale" in sel
+
+
+async def test_model_selection_fallback_for_unknown_type(api):
+    r = await api.post("/model-router/select", json={"task_type": "unknown-task-type-xyz"})
+    assert r.status_code == 200
+    sel = r.json()
+    assert sel["model_id"] == "llama3"
+    assert "fallback" in sel["rationale"]
+
+
+async def test_usage_record_and_summary(api):
+    obj_id = f"objectives:e2e-mr-{uuid.uuid4().hex[:8]}"
+
+    r = await api.post("/model-router/usage", json={
+        "objective_id": obj_id,
+        "model_id": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "input_tokens": 512,
+        "output_tokens": 256,
+        "cost_usd": 0.0012,
+    })
+    assert r.status_code == 200, r.text
+    record = r.json()
+    assert record["model_id"] == "claude-haiku-4-5"
+    assert record["cost_usd"] == 0.0012
+
+    # Summary (global)
+    r = await api.get("/model-router/usage/summary")
+    assert r.status_code == 200
+    summary = r.json()
+    assert "total_calls" in summary
+    assert "total_cost_usd" in summary
+
+    # Summary filtered by objective
+    r = await api.get("/model-router/usage/summary", params={"objective_id": obj_id})
+    assert r.status_code == 200
+    obj_summary = r.json()
+    assert obj_summary.get("total_calls", 0) >= 1
+
+    # Records list
+    r = await api.get("/model-router/usage/records", params={"objective_id": obj_id})
+    assert r.status_code == 200
+    records = r.json()
+    assert any(rec["objective_id"] == obj_id for rec in records)
+
+
+async def test_eval_dimensions_endpoint(api):
+    r = await api.get("/eval/dimensions")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["dimensions"] == ["completeness", "logical", "evidence", "accuracy", "relevance"]
+    assert body["default_threshold"] == 0.70

--- a/tests/e2e/test_workflows.py
+++ b/tests/e2e/test_workflows.py
@@ -1,0 +1,90 @@
+"""E2E: workflow run lifecycle and checkpoint store."""
+import uuid
+import pytest
+
+from conftest import bare_id
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_run_lifecycle(api):
+    obj_id = f"objectives:e2e-wf-{uuid.uuid4().hex[:8]}"
+
+    # Create run
+    r = await api.post("/workflows/runs", json={
+        "objective_id": obj_id,
+        "initial_state": {"step": 0, "data": []},
+    })
+    assert r.status_code == 200, r.text
+    run = r.json()
+    assert run["status"] == "running"
+    run_id = run["id"]
+    bare_run = bare_id(run_id)
+
+    # Fetch run
+    r = await api.get(f"/workflows/runs/{bare_run}")
+    assert r.status_code == 200
+    assert r.json()["id"] == run_id
+
+    # List runs for objective
+    r = await api.get(f"/workflows/objective/{obj_id}/runs")
+    assert r.status_code == 200
+    assert any(rr["id"] == run_id for rr in r.json())
+
+    # Update state
+    r = await api.patch(f"/workflows/runs/{bare_run}/state", json={
+        "state": {"step": 1, "data": ["item-a"]},
+        "status": "running",
+    })
+    assert r.status_code == 200
+
+    # Complete run
+    r = await api.post(f"/workflows/runs/{bare_run}/complete", json={
+        "state": {"step": 2, "data": ["item-a", "item-b"]},
+    })
+    assert r.status_code == 200
+    assert r.json()["status"] == "completed"
+
+
+async def test_run_failure(api):
+    obj_id = f"objectives:e2e-fail-{uuid.uuid4().hex[:8]}"
+
+    r = await api.post("/workflows/runs", json={"objective_id": obj_id})
+    assert r.status_code == 200
+    bare_run = bare_id(r.json()["id"])
+
+    r = await api.post(f"/workflows/runs/{bare_run}/fail", params={"error": "out of memory"})
+    assert r.status_code == 200
+    assert r.json()["status"] == "failed"
+
+
+async def test_checkpoint_save_and_restore(api):
+    obj_id = f"objectives:e2e-ckpt-{uuid.uuid4().hex[:8]}"
+    thread_id = f"thread-{uuid.uuid4().hex[:8]}"
+
+    r = await api.post("/workflows/runs", json={"objective_id": obj_id})
+    assert r.status_code == 200
+    bare_run = bare_id(r.json()["id"])
+
+    # Save checkpoint
+    r = await api.post(f"/workflows/runs/{bare_run}/checkpoints", json={
+        "thread_id": thread_id,
+        "node_id": "step_research",
+        "state": {"gathered_sources": 12, "tokens_used": 4096},
+        "metadata": {"phase": "research"},
+    })
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "checkpoint_id" in body
+    assert body["thread_id"] == thread_id
+
+    # Restore latest checkpoint
+    r = await api.get(f"/workflows/checkpoints/{thread_id}")
+    assert r.status_code == 200
+    restored = r.json()
+    assert restored["channel_values"]["gathered_sources"] == 12
+
+    # List checkpoints
+    r = await api.get(f"/workflows/checkpoints/{thread_id}/list")
+    assert r.status_code == 200
+    assert len(r.json()) >= 1


### PR DESCRIPTION
## Summary

- **`tests/e2e/`** — 5 pytest modules that run real HTTP against the live Docker Compose stack (no mocks):
  - `test_health.py` — `/health`, `/`, dashboard health, `X-Request-Id` header presence
  - `test_auth.py` — 401 without key, 401 with wrong key, 200 with valid key, CORS preflight
  - `test_full_workflow.py` — 18-step scenario: objective → workflow run → 2 agents → task → handoff → artifact → CLEAR eval → provenance → trust gate
  - `test_workflows.py` — run lifecycle (create/fetch/update/complete/fail) + checkpoint save & restore
  - `test_model_router.py` — routing rule upsert, model selection, fallback, usage record + summary
- **`scripts/run-e2e.sh`** — boots the stack, waits for health, runs pytest, tears down

## Test plan

- [ ] `./scripts/run-e2e.sh` — should bring up stack, pass all tests, tear down
- [ ] `./scripts/run-e2e.sh --keep-up` — stack stays up after tests for inspection
- [ ] With `E2E_API_KEY=your-key` set, auth tests run (requires `PLATFORM_API_KEYS` on server)
- [ ] Without `E2E_API_KEY`, auth tests auto-skip gracefully

https://claude.ai/code/session_01PiPbfiAqH4rPFeutHcPTK6

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiPbfiAqH4rPFeutHcPTK6)_