### PR TITLE
Set canonical truth governance in Agent Card

### DIFF
--- a/AGENTS.agentql
+++ b/AGENTS.agentql
@@ -2,6 +2,9 @@ namespace agennext.platform.agents
 
 vocabulary platform_agent_instructions {
   term no_python_business_logic means "Python must not contain product or runtime business logic" maps to platform.governance.no_python_business_logic
+  term canonical_truth means "Canonical truth is a protected published commit SHA plus required check evidence and signed report evidence" maps to platform.governance.canonical_truth
+  term effective_canonical_truth means "The latest valid canonical record in the requested scope is the current truth in effect" maps to platform.governance.effective_canonical_truth
+  term checks_authority means "Checks owns check definitions, execution records, evidence, and signed check reports" maps to platform.governance.checks_authority
   term quorum_consensus means "Design and semantic changes require quorum consensus" maps to platform.governance.quorum
   term agentql_doc_source means "README and AGENTS content is authored in AgentQL first" maps to platform.documentation.agentql_source
   term same_language_loop means "Agents read, validate, write, and present governance meaning in AgentQL to reduce hallucination risk" maps to platform.documentation.same_language_loop
@@ -25,6 +28,13 @@ constitution PlatformAgentInstructions {
   rule llm_limited_scope: "LLMs are tools for open-ended language work only and their outputs must be written back into SurrealDB as governed state with provenance."
   rule no_external_business_logic: "Do not implement business logic in Python, JavaScript, TypeScript, shell scripts, YAML, external services, or frontend code."
   rule quorum_for_business_logic_deviation: "Any proposal to place business logic outside SurrealDB requires quorum consensus before implementation."
+  rule canonical_truth_source: "Only protected published commit SHAs with required check evidence and signed report evidence are canonical truth."
+  rule no_name_truth: "Repository names, branch names without SHAs, README text, screenshots, local working trees, and unstamped claims are not truth."
+  rule immutable_canonical_records: "Canonical records are append-only and must never be edited or deleted."
+  rule latest_valid_effective: "The latest valid canonical record in the requested scope is the effective truth because it is what is in effect."
+  rule checks_authority: "Checks owns check definitions, check execution records, evidence, signed check reports, and provider/tool check adapters."
+  rule commit_deploy_consumers: "Agent-Commit consumes Checks evidence before commit or pull request; Agent-deploy verifies Checks evidence before deployment."
+  rule grammar_not_ontology: "Agent-Grammar owns grammar; ontology owns meaning; Checks owns check-domain execution records and adapter contracts only."
   rule edge_validation: "Validation and authoring feedback must be fast and delivered at the edge."
   rule browser_typescript_only: "Outside SurrealDB, SurrealQL, SurrealML, and AgentQL, the only approved implementation language is browser-side TypeScript."
   rule typescript_scope: "TypeScript is allowed only for user/browser UI, browser-side AgentQL authoring, browser-side validation hints, browser-side editor tooling, and edge-delivered validation UX."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,29 @@ Any proposal to place business logic outside SurrealDB requires quorum consensus
 
 No quorum, no exception.
 
+## Canonical Truth
+
+Canonical truth is a protected published commit SHA plus required check evidence and signed report evidence.
+
+The following are not truth:
+
+- repository names
+- branch names without SHAs
+- README text
+- screenshots
+- local working trees
+- unstamped claims
+
+Canonical records are append-only and must never be edited or deleted.
+
+The latest valid canonical record in the requested scope is the effective truth because it is what is in effect.
+
+Checks owns check definitions, check execution records, evidence, signed check reports, and provider/tool check adapters.
+
+Agent-Commit consumes Checks evidence before commit or pull request. Agent-deploy verifies Checks evidence before deployment.
+
+Agent-Grammar owns grammar. Ontology owns meaning. Checks owns check-domain execution records and adapter contracts only.
+
 ## CI/CD Enforcement
 
 Every repository must include a CI/CD governance check that fails when Python business logic is introduced.
@@ -62,11 +85,7 @@ The check must reject Python-owned:
 - runtime state mutation
 - product/domain models
 
-Agent-Platform enforces this through the centralized Agent-deploy governance workflow. The editable validation definitions live in:
-
-```text
-governance/no-python-business-logic.rules.tsv
-```
+Agent-Platform enforces this through the required Checks status for the protected published commit SHA. Transitional workflows must be migrated to Checks ownership.
 
 The check is intentionally strict. Existing violations must be migrated to SurrealDB `DEFINE API`, SurrealQL custom functions, SurrealDB events/permissions, AgentQL-generated SurrealQL, or SurrealML bindings.
 


### PR DESCRIPTION
## Purpose

Update Agent Card instructions so governance uses canonical published truth instead of repo names, README claims, local state, or stale Agent-deploy ownership language.

## Rules encoded

- Canonical truth is protected published commit SHA + required check evidence + signed report evidence.
- Canonical records are append-only and immutable.
- Effective truth is the latest valid canonical record in scope.
- Checks owns check records/evidence/reports/adapters.
- Agent-Commit consumes Checks evidence.
- Agent-deploy verifies Checks evidence before deploy.
- Agent-Grammar owns grammar; ontology owns meaning.

## Source of truth

This PR changes AGENTS files only. README is not used as truth.