### PR TITLE
Build Autonomyx OAM stack scaffold

### DIFF
--- a/autonomyx-stack/.github/workflows/check.yml
+++ b/autonomyx-stack/.github/workflows/check.yml
@@ -25,3 +25,21 @@ jobs:
           cache-dependency-path: autonomyx-stack/package.json
       - run: npm install
       - run: npm run check
+      - run: npm run validate:stack
+      - run: npm run build
+
+  image:
+    runs-on: ubuntu-latest
+    needs: check
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: autonomyx-stack
+          push: false
+          tags: ghcr.io/agennext/autonomyx-controller:0.1.0
+          load: false

--- a/autonomyx-stack/.github/workflows/check.yml
+++ b/autonomyx-stack/.github/workflows/check.yml
@@ -1,0 +1,27 @@
+name: Autonomyx Stack Check
+
+on:
+  pull_request:
+    paths:
+      - "autonomyx-stack/**"
+  push:
+    branches:
+      - autonomyx-oam-stack
+    paths:
+      - "autonomyx-stack/**"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: autonomyx-stack
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: autonomyx-stack/package.json
+      - run: npm install
+      - run: npm run check

--- a/autonomyx-stack/Dockerfile
+++ b/autonomyx-stack/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:22-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install
+
+FROM deps AS build
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+FROM node:22-alpine AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+ENV AUTONOMYX_WEBHOOK_PORT=8443
+COPY package.json ./
+RUN npm install --omit=dev
+COPY --from=build /app/dist ./dist
+EXPOSE 8443
+CMD ["node", "dist/controller/server.js"]

--- a/autonomyx-stack/Dockerfile
+++ b/autonomyx-stack/Dockerfile
@@ -11,9 +11,12 @@ RUN npm run build
 FROM node:22-alpine AS runtime
 WORKDIR /app
 ENV NODE_ENV=production
+ENV AUTONOMYX_MVP_PORT=8080
 ENV AUTONOMYX_WEBHOOK_PORT=8443
 COPY package.json ./
 RUN npm install --omit=dev
 COPY --from=build /app/dist ./dist
-EXPOSE 8443
-CMD ["node", "dist/controller/server.js"]
+COPY autonomyx.manifest.yaml ./autonomyx.manifest.yaml
+COPY bindings ./bindings
+EXPOSE 8080 8443
+CMD ["node", "dist/mvp/server.js"]

--- a/autonomyx-stack/README.md
+++ b/autonomyx-stack/README.md
@@ -1,0 +1,84 @@
+# Autonomyx OAM Stack
+
+Autonomyx is implemented here as an **Open Application Governance Platform**: every capability is modeled as an OAM-style application, every application is a gate, and every execution is domain-bound, policy-governed, graph-backed, audited, and certifiable.
+
+## Canonical position
+
+Autonomyx does not replace Kubernetes, OAM, SPIFFE, OPA, OpenTelemetry, SLSA, or Sigstore. It composes them into a governed execution fabric.
+
+## Stack apps
+
+### Foundation
+
+- `autonomyx-domain`
+- `autonomyx-identity`
+- `autonomyx-policy`
+- `autonomyx-graph`
+
+### Governance
+
+- `autonomyx-trust`
+- `autonomyx-certification`
+- `autonomyx-audit`
+
+### Runtime
+
+- `autonomyx-runtime`
+- `autonomyx-publication`
+- `autonomyx-discovery`
+
+### OAM
+
+- `autonomyx-oam`
+- `autonomyx-manifest`
+
+### Experience
+
+- `autodesk`
+- `autobuilder`
+- `autograph`
+- `autotrust`
+- `autopolicy`
+- `autopublish`
+- `autocertify`
+
+## Runtime law
+
+```text
+Surface request
+  -> rebase
+  -> domain resolution
+  -> gate decision
+  -> graph arithmetic
+  -> audit
+  -> certification-ready record
+```
+
+## Run locally
+
+```bash
+cd autonomyx-stack
+npm install
+npm run dev
+```
+
+## Build
+
+```bash
+npm run build
+npm start
+```
+
+## Key files
+
+- `autonomyx.manifest.yaml` — canonical binding contract.
+- `src/types.ts` — platform object model.
+- `src/kernel.ts` — deterministic logical kernel.
+- `src/apps.ts` — every stack component as an app.
+- `src/platform.ts` — composition layer.
+- `policy/gate.rego` — OPA gate policy.
+- `docs/oam-mapping.md` — OAM-to-Autonomyx mapping.
+
+## Current scope
+
+This is a first-pass runnable scaffold. It is not yet a production control plane. Next steps are Kubernetes CRDs, OPA bundle integration, SPIFFE workload identity, OpenTelemetry instrumentation, and supply-chain certification wiring.

--- a/autonomyx-stack/README.md
+++ b/autonomyx-stack/README.md
@@ -47,10 +47,13 @@ Autonomyx does not replace Kubernetes, OAM, SPIFFE, OPA, OpenTelemetry, SLSA, or
 ```text
 Surface request
   -> rebase
+  -> identity extraction
   -> domain resolution
-  -> gate decision
+  -> trust scoring
+  -> policy evaluation
+  -> CRD reconciliation
   -> graph arithmetic
-  -> audit
+  -> audit/telemetry
   -> certification-ready record
 ```
 
@@ -75,6 +78,15 @@ The controller exposes:
 
 - `GET /healthz`
 - `POST /admit`
+
+Example admission test:
+
+```bash
+curl -X POST http://localhost:8443/admit \
+  -H 'content-type: application/json' \
+  -H 'x-spiffe-id: spiffe://autonomyx.local/ns/default/sa/operator' \
+  --data @examples/admission-review.json
+```
 
 ## Build
 
@@ -111,13 +123,18 @@ The stack is bound in two places:
 - `src/kernel.ts` — deterministic logical kernel.
 - `src/apps.ts` — every stack component as an app.
 - `src/platform.ts` — composition layer.
+- `src/security/identity.ts` — SPIFFE/OIDC/Kubernetes identity extraction.
+- `src/security/policy.ts` — deny-by-default policy mirror.
+- `src/security/certification.ts` — certification verifier scaffold.
+- `src/observability/telemetry.ts` — structured telemetry event writer.
 - `src/controller/server.ts` — HTTP admission server.
 - `src/controller/admission.ts` — AdmissionReview decision adapter.
 - `src/controller/reconciler.ts` — CRD reconcile rules.
 - `policy/gate.rego` — OPA gate policy.
 - `docs/oam-mapping.md` — OAM-to-Autonomyx mapping.
 - `docs/kubernetes.md` — Kubernetes install guide.
+- `docs/runbook.md` — operator runbook.
 
 ## Current scope
 
-This is now a runnable TypeScript scaffold plus a Kubernetes-native resource model and admission endpoint. It is not yet a production-grade controller image with TLS automation, live Kubernetes watches, SPIFFE extraction, OPA bundle runtime, OpenTelemetry export, or Sigstore/SLSA verification.
+This is now a runnable TypeScript scaffold plus a Kubernetes-native resource model, admission endpoint, identity extraction, policy evaluation, telemetry emission, certification checks, Dockerfile, and binding contract. It is not yet a production-grade controller with TLS automation, live Kubernetes watches, real OPA bundle runtime, OpenTelemetry SDK exporter, SPIFFE Workload API integration, or Sigstore/SLSA verification implementation.

--- a/autonomyx-stack/README.md
+++ b/autonomyx-stack/README.md
@@ -62,23 +62,62 @@ npm install
 npm run dev
 ```
 
+## Run the admission controller locally
+
+```bash
+cd autonomyx-stack
+npm install
+npm run controller:dev
+curl http://localhost:8443/healthz
+```
+
+The controller exposes:
+
+- `GET /healthz`
+- `POST /admit`
+
 ## Build
 
 ```bash
 npm run build
 npm start
+npm run controller:start
 ```
+
+## Build controller image
+
+```bash
+docker build -t ghcr.io/agennext/autonomyx-controller:0.1.0 .
+```
+
+## Apply the bound Kubernetes stack
+
+```bash
+kubectl apply -k deploy/
+```
+
+## Binding
+
+The stack is bound in two places:
+
+- `deploy/kustomization.yaml` binds Kubernetes resources into one apply unit.
+- `bindings/autonomyx.stack.binding.yaml` binds OAM apps to domains, gates, policy, publication, and certification.
 
 ## Key files
 
 - `autonomyx.manifest.yaml` — canonical binding contract.
+- `bindings/autonomyx.stack.binding.yaml` — app/domain/gate/certification binding.
 - `src/types.ts` — platform object model.
 - `src/kernel.ts` — deterministic logical kernel.
 - `src/apps.ts` — every stack component as an app.
 - `src/platform.ts` — composition layer.
+- `src/controller/server.ts` — HTTP admission server.
+- `src/controller/admission.ts` — AdmissionReview decision adapter.
+- `src/controller/reconciler.ts` — CRD reconcile rules.
 - `policy/gate.rego` — OPA gate policy.
 - `docs/oam-mapping.md` — OAM-to-Autonomyx mapping.
+- `docs/kubernetes.md` — Kubernetes install guide.
 
 ## Current scope
 
-This is a first-pass runnable scaffold. It is not yet a production control plane. Next steps are Kubernetes CRDs, OPA bundle integration, SPIFFE workload identity, OpenTelemetry instrumentation, and supply-chain certification wiring.
+This is now a runnable TypeScript scaffold plus a Kubernetes-native resource model and admission endpoint. It is not yet a production-grade controller image with TLS automation, live Kubernetes watches, SPIFFE extraction, OPA bundle runtime, OpenTelemetry export, or Sigstore/SLSA verification.

--- a/autonomyx-stack/README.md
+++ b/autonomyx-stack/README.md
@@ -2,6 +2,39 @@
 
 Autonomyx is implemented here as an **Open Application Governance Platform**: every capability is modeled as an OAM-style application, every application is a gate, and every execution is domain-bound, policy-governed, graph-backed, audited, and certifiable.
 
+## MVP
+
+The MVP is now a usable control-plane surface:
+
+- browser operator UI at `/`
+- app registry at `/api/apps`
+- state view at `/api/state`
+- manifest view at `/api/manifest`
+- binding view at `/api/binding`
+- execution endpoint at `/api/execute`
+- admission endpoint at `/admit`
+
+Run it locally:
+
+```bash
+cd autonomyx-stack
+npm install
+npm run mvp:dev
+```
+
+Open:
+
+```text
+http://localhost:8080
+```
+
+Run it in Kubernetes:
+
+```bash
+kubectl apply -k deploy/
+kubectl -n autonomyx-system port-forward svc/autonomyx-mvp 8080:80
+```
+
 ## Canonical position
 
 Autonomyx does not replace Kubernetes, OAM, SPIFFE, OPA, OpenTelemetry, SLSA, or Sigstore. It composes them into a governed execution fabric.
@@ -57,14 +90,6 @@ Surface request
   -> certification-ready record
 ```
 
-## Run locally
-
-```bash
-cd autonomyx-stack
-npm install
-npm run dev
-```
-
 ## Run the admission controller locally
 
 ```bash
@@ -93,10 +118,11 @@ curl -X POST http://localhost:8443/admit \
 ```bash
 npm run build
 npm start
+npm run mvp:start
 npm run controller:start
 ```
 
-## Build controller image
+## Build controller/MVP image
 
 ```bash
 docker build -t ghcr.io/agennext/autonomyx-controller:0.1.0 .
@@ -123,6 +149,8 @@ The stack is bound in two places:
 - `src/kernel.ts` — deterministic logical kernel.
 - `src/apps.ts` — every stack component as an app.
 - `src/platform.ts` — composition layer.
+- `src/mvp/server.ts` — MVP API server.
+- `src/mvp/html.ts` — MVP browser UI.
 - `src/security/identity.ts` — SPIFFE/OIDC/Kubernetes identity extraction.
 - `src/security/policy.ts` — deny-by-default policy mirror.
 - `src/security/certification.ts` — certification verifier scaffold.
@@ -134,7 +162,8 @@ The stack is bound in two places:
 - `docs/oam-mapping.md` — OAM-to-Autonomyx mapping.
 - `docs/kubernetes.md` — Kubernetes install guide.
 - `docs/runbook.md` — operator runbook.
+- `docs/mvp.md` — MVP guide.
 
 ## Current scope
 
-This is now a runnable TypeScript scaffold plus a Kubernetes-native resource model, admission endpoint, identity extraction, policy evaluation, telemetry emission, certification checks, Dockerfile, and binding contract. It is not yet a production-grade controller with TLS automation, live Kubernetes watches, real OPA bundle runtime, OpenTelemetry SDK exporter, SPIFFE Workload API integration, or Sigstore/SLSA verification implementation.
+This is now a runnable MVP control plane plus a Kubernetes-native resource model, admission endpoint, identity extraction, policy evaluation, telemetry emission, certification checks, Dockerfile, deploy bundle, and binding contract. It is not yet a production-grade controller with persistent database, login UI, TLS automation, live Kubernetes watches, real OPA bundle runtime, OpenTelemetry SDK exporter, SPIFFE Workload API integration, or Sigstore/SLSA verification implementation.

--- a/autonomyx-stack/autonomyx.manifest.yaml
+++ b/autonomyx-stack/autonomyx.manifest.yaml
@@ -1,0 +1,66 @@
+apiVersion: autonomyx.io/v1alpha1
+kind: AutonomyxManifest
+metadata:
+  name: autonomyx-oam-stack
+  domain: platform
+spec:
+  protocol:
+    pinnedTo: Open Application Model
+    source: https://www.cncf.io/blog/2020/07/24/open-application-model-carving-building-blocks-for-platforms/
+  invariants:
+    noSubAgents: true
+    noSubGraphs: true
+    noSidecarsInLogicLayer: true
+    rebaseAtEverySurface: true
+    eligibilityBeforeDiscovery: true
+    jitAccess: true
+    jitAuthorization: true
+    immutablePublication: true
+    timeBoundArtifacts: true
+    everyExchangeTransactional: true
+    everyApplicationIsGate: true
+  substrates:
+    liquid: runtime-flow
+    solid: persistent-state
+  state:
+    model: single-graph
+    semanticFormat: JSON-LD
+    graphName: AnyData
+  standards:
+    application: OAM
+    orchestration: Kubernetes
+    policy: OPA/Rego
+    identity: SPIFFE/OIDC
+    observability: OpenTelemetry
+    supplyChain: SLSA/Sigstore/SBOM
+  oamMapping:
+    component: Publication
+    trait: Policy
+    scope: Domain
+    workflow: ExecutionChain
+    applicationConfiguration: autonomyx.manifest
+  apps:
+    foundation:
+      - autonomyx-domain
+      - autonomyx-identity
+      - autonomyx-policy
+      - autonomyx-graph
+    governance:
+      - autonomyx-trust
+      - autonomyx-certification
+      - autonomyx-audit
+    runtime:
+      - autonomyx-runtime
+      - autonomyx-publication
+      - autonomyx-discovery
+    oam:
+      - autonomyx-oam
+      - autonomyx-manifest
+    experience:
+      - autodesk
+      - autobuilder
+      - autograph
+      - autotrust
+      - autopolicy
+      - autopublish
+      - autocertify

--- a/autonomyx-stack/bindings/autonomyx.stack.binding.yaml
+++ b/autonomyx-stack/bindings/autonomyx.stack.binding.yaml
@@ -1,0 +1,45 @@
+apiVersion: autonomyx.io/v1alpha1
+kind: AutonomyxStackBinding
+metadata:
+  name: autonomyx-oam-stack-binding
+spec:
+  rootManifest: autonomyx-oam-stack
+  protocol:
+    pinnedTo: Open Application Model
+    binding: autonomyx.manifest
+  domainBindings:
+    platform:
+      domainRef: platform
+      gateRef: autonomyx-default-gate
+      policyRef: policy/gate.rego
+  appBindings:
+    autonomyx-domain:
+      kind: Domain
+      domain: platform
+      gate: autonomyx-default-gate
+    autonomyx-policy:
+      kind: Gate
+      domain: platform
+      gate: autonomyx-default-gate
+    autonomyx-runtime:
+      kind: AutonomyxManifest
+      domain: runtime
+      gate: autonomyx-default-gate
+    autonomyx-certification:
+      kind: Certification
+      domain: governance
+      gate: autonomyx-default-gate
+    autonomyx-publication:
+      kind: Publication
+      domain: runtime
+      gate: autonomyx-default-gate
+    autodesk:
+      kind: AutonomyxManifest
+      domain: workspace
+      gate: autonomyx-default-gate
+  invariants:
+    everyApplicationIsGate: true
+    everyResourceHasDomain: true
+    everyPublicationRequiresCertification: true
+    everyAdmissionRebases: true
+    everyDecisionAuditable: true

--- a/autonomyx-stack/deploy/controller.yaml
+++ b/autonomyx-stack/deploy/controller.yaml
@@ -33,6 +33,19 @@ spec:
               value: "true"
             - name: AUTONOMYX_GATE_MODE
               value: deny-by-default
+            - name: AUTONOMYX_TLS_CERT_FILE
+              value: /var/run/autonomyx/tls/tls.crt
+            - name: AUTONOMYX_TLS_KEY_FILE
+              value: /var/run/autonomyx/tls/tls.key
+          volumeMounts:
+            - name: webhook-tls
+              mountPath: /var/run/autonomyx/tls
+              readOnly: true
+      volumes:
+        - name: webhook-tls
+          secret:
+            secretName: autonomyx-controller-webhook-tls
+            optional: true
 ---
 apiVersion: v1
 kind: Service

--- a/autonomyx-stack/deploy/controller.yaml
+++ b/autonomyx-stack/deploy/controller.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: autonomyx-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: autonomyx-controller
+  namespace: autonomyx-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: autonomyx-controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: autonomyx-controller
+    spec:
+      serviceAccountName: autonomyx-controller
+      containers:
+        - name: controller
+          image: ghcr.io/agennext/autonomyx-controller:0.1.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: webhook
+              containerPort: 8443
+          env:
+            - name: AUTONOMYX_MODE
+              value: oam-stack
+            - name: AUTONOMYX_REQUIRE_REBASE
+              value: "true"
+            - name: AUTONOMYX_GATE_MODE
+              value: deny-by-default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: autonomyx-controller
+  namespace: autonomyx-system
+spec:
+  selector:
+    app.kubernetes.io/name: autonomyx-controller
+  ports:
+    - name: webhook
+      port: 443
+      targetPort: webhook

--- a/autonomyx-stack/deploy/crds/autonomyx.io_autonomyxmanifests.yaml
+++ b/autonomyx-stack/deploy/crds/autonomyx.io_autonomyxmanifests.yaml
@@ -1,0 +1,88 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: autonomyxmanifests.autonomyx.io
+spec:
+  group: autonomyx.io
+  scope: Namespaced
+  names:
+    plural: autonomyxmanifests
+    singular: autonomyxmanifest
+    kind: AutonomyxManifest
+    shortNames:
+      - axm
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [domain, apps]
+              properties:
+                domain:
+                  type: string
+                  minLength: 1
+                protocol:
+                  type: object
+                  properties:
+                    pinnedTo:
+                      type: string
+                    source:
+                      type: string
+                invariants:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                standards:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                apps:
+                  type: array
+                  items:
+                    type: object
+                    required: [name, tier, domain]
+                    properties:
+                      name:
+                        type: string
+                      tier:
+                        type: string
+                        enum: [foundation, governance, runtime, oam, experience]
+                      domain:
+                        type: string
+                      component:
+                        type: string
+                      traits:
+                        type: array
+                        items:
+                          type: string
+                      workflows:
+                        type: array
+                        items:
+                          type: string
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                observedGeneration:
+                  type: integer
+                certified:
+                  type: boolean
+                message:
+                  type: string
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Domain
+          type: string
+          jsonPath: .spec.domain
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Certified
+          type: boolean
+          jsonPath: .status.certified

--- a/autonomyx-stack/deploy/crds/autonomyx.io_certifications.yaml
+++ b/autonomyx-stack/deploy/crds/autonomyx.io_certifications.yaml
@@ -1,0 +1,76 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: certifications.autonomyx.io
+spec:
+  group: autonomyx.io
+  scope: Namespaced
+  names:
+    plural: certifications
+    singular: certification
+    kind: Certification
+    shortNames:
+      - axc
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [domain, subject, provenance]
+              properties:
+                domain:
+                  type: string
+                subject:
+                  type: string
+                provenance:
+                  type: object
+                  required: [source, digest]
+                  properties:
+                    source:
+                      type: string
+                    digest:
+                      type: string
+                    sbomRef:
+                      type: string
+                    signatureRef:
+                      type: string
+                    slsaLevel:
+                      type: string
+                validFrom:
+                  type: string
+                  format: date-time
+                validUntil:
+                  type: string
+                  format: date-time
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                certified:
+                  type: boolean
+                trustScore:
+                  type: number
+                message:
+                  type: string
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Domain
+          type: string
+          jsonPath: .spec.domain
+        - name: Subject
+          type: string
+          jsonPath: .spec.subject
+        - name: Certified
+          type: boolean
+          jsonPath: .status.certified
+        - name: Trust
+          type: number
+          jsonPath: .status.trustScore

--- a/autonomyx-stack/deploy/crds/autonomyx.io_domains.yaml
+++ b/autonomyx-stack/deploy/crds/autonomyx.io_domains.yaml
@@ -1,0 +1,62 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: domains.autonomyx.io
+spec:
+  group: autonomyx.io
+  scope: Cluster
+  names:
+    plural: domains
+    singular: domain
+    kind: Domain
+    shortNames:
+      - axd
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [name, scope]
+              properties:
+                name:
+                  type: string
+                scope:
+                  type: string
+                  enum: [foundation, governance, runtime, oam, experience]
+                ownerRef:
+                  type: string
+                  description: External owner reference. Owner remains outside runtime authority.
+                status:
+                  type: string
+                  enum: [trusted, verified, suspended]
+                policies:
+                  type: array
+                  items:
+                    type: string
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                trustScore:
+                  type: number
+                message:
+                  type: string
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Scope
+          type: string
+          jsonPath: .spec.scope
+        - name: Status
+          type: string
+          jsonPath: .spec.status
+        - name: Trust
+          type: number
+          jsonPath: .status.trustScore

--- a/autonomyx-stack/deploy/crds/autonomyx.io_gates.yaml
+++ b/autonomyx-stack/deploy/crds/autonomyx.io_gates.yaml
@@ -1,0 +1,65 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: gates.autonomyx.io
+spec:
+  group: autonomyx.io
+  scope: Namespaced
+  names:
+    plural: gates
+    singular: gate
+    kind: Gate
+    shortNames:
+      - axg
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [domain, policyRef, mode]
+              properties:
+                domain:
+                  type: string
+                mode:
+                  type: string
+                  enum: [deny-by-default]
+                policyRef:
+                  type: string
+                trustThreshold:
+                  type: number
+                  default: 0.5
+                jitAccess:
+                  type: boolean
+                  default: true
+                jitAuthorization:
+                  type: boolean
+                  default: true
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                allowed:
+                  type: integer
+                denied:
+                  type: integer
+                message:
+                  type: string
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Domain
+          type: string
+          jsonPath: .spec.domain
+        - name: Mode
+          type: string
+          jsonPath: .spec.mode
+        - name: Threshold
+          type: number
+          jsonPath: .spec.trustThreshold

--- a/autonomyx-stack/deploy/crds/autonomyx.io_publications.yaml
+++ b/autonomyx-stack/deploy/crds/autonomyx.io_publications.yaml
@@ -1,0 +1,67 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: publications.autonomyx.io
+spec:
+  group: autonomyx.io
+  scope: Namespaced
+  names:
+    plural: publications
+    singular: publication
+    kind: Publication
+    shortNames:
+      - axp
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [domain, artifact, immutable]
+              properties:
+                domain:
+                  type: string
+                artifact:
+                  type: string
+                version:
+                  type: string
+                immutable:
+                  type: boolean
+                  default: true
+                effectiveFrom:
+                  type: string
+                  format: date-time
+                expiresAt:
+                  type: string
+                  format: date-time
+                certificationRef:
+                  type: string
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                digest:
+                  type: string
+                publishedAt:
+                  type: string
+                  format: date-time
+                message:
+                  type: string
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Domain
+          type: string
+          jsonPath: .spec.domain
+        - name: Version
+          type: string
+          jsonPath: .spec.version
+        - name: Phase
+          type: string
+          jsonPath: .status.phase

--- a/autonomyx-stack/deploy/kustomization.yaml
+++ b/autonomyx-stack/deploy/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - tls/webhook-tls-secret.example.yaml
   - rbac.yaml
   - controller.yaml
+  - mvp.yaml
   - webhook.yaml
   - samples/domain-platform.yaml
   - samples/gate-default.yaml

--- a/autonomyx-stack/deploy/kustomization.yaml
+++ b/autonomyx-stack/deploy/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - crds/autonomyx.io_autonomyxmanifests.yaml
+  - crds/autonomyx.io_domains.yaml
+  - crds/autonomyx.io_gates.yaml
+  - crds/autonomyx.io_publications.yaml
+  - crds/autonomyx.io_certifications.yaml
+  - rbac.yaml
+  - controller.yaml
+  - webhook.yaml
+  - samples/domain-platform.yaml
+  - samples/gate-default.yaml
+  - samples/certification-stack.yaml
+  - samples/publication-stack.yaml
+  - samples/manifest-stack.yaml
+
+images:
+  - name: ghcr.io/agennext/autonomyx-controller
+    newTag: 0.1.0

--- a/autonomyx-stack/deploy/kustomization.yaml
+++ b/autonomyx-stack/deploy/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - crds/autonomyx.io_gates.yaml
   - crds/autonomyx.io_publications.yaml
   - crds/autonomyx.io_certifications.yaml
+  - tls/webhook-tls-secret.example.yaml
   - rbac.yaml
   - controller.yaml
   - webhook.yaml

--- a/autonomyx-stack/deploy/mvp.yaml
+++ b/autonomyx-stack/deploy/mvp.yaml
@@ -1,3 +1,24 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: autonomyx-mvp-state
+  namespace: autonomyx-system
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: autonomyx-mvp-auth
+  namespace: autonomyx-system
+type: Opaque
+stringData:
+  token: change-me
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -24,6 +45,20 @@ spec:
           env:
             - name: AUTONOMYX_MVP_PORT
               value: "8080"
+            - name: AUTONOMYX_STATE_FILE
+              value: /var/lib/autonomyx/state/autonomyx-state.json
+            - name: AUTONOMYX_MVP_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: autonomyx-mvp-auth
+                  key: token
+          volumeMounts:
+            - name: state
+              mountPath: /var/lib/autonomyx/state
+      volumes:
+        - name: state
+          persistentVolumeClaim:
+            claimName: autonomyx-mvp-state
 ---
 apiVersion: v1
 kind: Service

--- a/autonomyx-stack/deploy/mvp.yaml
+++ b/autonomyx-stack/deploy/mvp.yaml
@@ -19,6 +19,16 @@ type: Opaque
 stringData:
   token: change-me
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: autonomyx-surrealdb-auth
+  namespace: autonomyx-system
+type: Opaque
+stringData:
+  username: root
+  password: root
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -45,8 +55,30 @@ spec:
           env:
             - name: AUTONOMYX_MVP_PORT
               value: "8080"
+            - name: AUTONOMYX_STATE_PROVIDER
+              value: json
             - name: AUTONOMYX_STATE_FILE
               value: /var/lib/autonomyx/state/autonomyx-state.json
+            - name: AUTONOMYX_STATE_RECORD_ID
+              value: autonomyx_state:mvp
+            - name: SURREALDB_ENDPOINT
+              value: http://surrealdb.fabric.svc.cluster.local:8000
+            - name: SURREALDB_NAMESPACE
+              value: agennext
+            - name: SURREALDB_DATABASE
+              value: fabric
+            - name: SURREALDB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: autonomyx-surrealdb-auth
+                  key: username
+                  optional: true
+            - name: SURREALDB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: autonomyx-surrealdb-auth
+                  key: password
+                  optional: true
             - name: AUTONOMYX_MVP_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/autonomyx-stack/deploy/mvp.yaml
+++ b/autonomyx-stack/deploy/mvp.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: autonomyx-mvp
+  namespace: autonomyx-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: autonomyx-mvp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: autonomyx-mvp
+    spec:
+      serviceAccountName: autonomyx-controller
+      containers:
+        - name: mvp
+          image: ghcr.io/agennext/autonomyx-controller:0.1.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: AUTONOMYX_MVP_PORT
+              value: "8080"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: autonomyx-mvp
+  namespace: autonomyx-system
+spec:
+  selector:
+    app.kubernetes.io/name: autonomyx-mvp
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/autonomyx-stack/deploy/rbac.yaml
+++ b/autonomyx-stack/deploy/rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: autonomyx-controller
+  namespace: autonomyx-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: autonomyx-controller
+rules:
+  - apiGroups: ["autonomyx.io"]
+    resources:
+      - autonomyxmanifests
+      - domains
+      - gates
+      - publications
+      - certifications
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["autonomyx.io"]
+    resources:
+      - autonomyxmanifests/status
+      - domains/status
+      - gates/status
+      - publications/status
+      - certifications/status
+    verbs: ["get", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: autonomyx-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: autonomyx-controller
+subjects:
+  - kind: ServiceAccount
+    name: autonomyx-controller
+    namespace: autonomyx-system

--- a/autonomyx-stack/deploy/samples/certification-stack.yaml
+++ b/autonomyx-stack/deploy/samples/certification-stack.yaml
@@ -1,0 +1,16 @@
+apiVersion: autonomyx.io/v1alpha1
+kind: Certification
+metadata:
+  name: autonomyx-stack-v0-1
+  namespace: default
+spec:
+  domain: platform
+  subject: ghcr.io/agennext/autonomyx-controller:0.1.0
+  provenance:
+    source: AGenNext/Agent-Platform
+    digest: sha256:replace-me
+    sbomRef: sbom:replace-me
+    signatureRef: cosign:replace-me
+    slsaLevel: build-l1
+  validFrom: "2026-06-24T00:00:00+05:30"
+  validUntil: "2026-12-24T00:00:00+05:30"

--- a/autonomyx-stack/deploy/samples/domain-platform.yaml
+++ b/autonomyx-stack/deploy/samples/domain-platform.yaml
@@ -1,0 +1,11 @@
+apiVersion: autonomyx.io/v1alpha1
+kind: Domain
+metadata:
+  name: platform
+spec:
+  name: Platform
+  scope: foundation
+  ownerRef: external:domain-owner:platform
+  status: verified
+  policies:
+    - autonomyx-default-gate

--- a/autonomyx-stack/deploy/samples/gate-default.yaml
+++ b/autonomyx-stack/deploy/samples/gate-default.yaml
@@ -1,0 +1,12 @@
+apiVersion: autonomyx.io/v1alpha1
+kind: Gate
+metadata:
+  name: autonomyx-default-gate
+  namespace: default
+spec:
+  domain: platform
+  mode: deny-by-default
+  policyRef: policy/gate.rego
+  trustThreshold: 0.5
+  jitAccess: true
+  jitAuthorization: true

--- a/autonomyx-stack/deploy/samples/manifest-stack.yaml
+++ b/autonomyx-stack/deploy/samples/manifest-stack.yaml
@@ -1,0 +1,48 @@
+apiVersion: autonomyx.io/v1alpha1
+kind: AutonomyxManifest
+metadata:
+  name: autonomyx-oam-stack
+  namespace: default
+spec:
+  domain: platform
+  protocol:
+    pinnedTo: Open Application Model
+    source: https://www.cncf.io/blog/2020/07/24/open-application-model-carving-building-blocks-for-platforms/
+  invariants:
+    rebaseAtEverySurface: true
+    eligibilityBeforeDiscovery: true
+    jitAccess: true
+    jitAuthorization: true
+    immutablePublication: true
+    everyApplicationIsGate: true
+  standards:
+    orchestration: Kubernetes
+    policy: OPA/Rego
+    identity: SPIFFE/OIDC
+    observability: OpenTelemetry
+    supplyChain: SLSA/Sigstore/SBOM
+  apps:
+    - name: autonomyx-domain
+      tier: foundation
+      domain: platform
+      component: autonomyx-domain
+      traits: [domain-bound, gate-enforced, audited]
+      workflows: [rebase, authorize, execute, audit]
+    - name: autonomyx-policy
+      tier: foundation
+      domain: platform
+      component: autonomyx-policy
+      traits: [opa, deny-by-default, audited]
+      workflows: [evaluate, publish, audit]
+    - name: autonomyx-runtime
+      tier: runtime
+      domain: runtime
+      component: autonomyx-runtime
+      traits: [rebase, kernel, graph-arithmetic, audited]
+      workflows: [execute, publish, certify]
+    - name: autodesk
+      tier: experience
+      domain: workspace
+      component: autodesk
+      traits: [operator-workspace, domain-bound, audited]
+      workflows: [discover, operate, govern, publish]

--- a/autonomyx-stack/deploy/samples/publication-stack.yaml
+++ b/autonomyx-stack/deploy/samples/publication-stack.yaml
@@ -1,0 +1,13 @@
+apiVersion: autonomyx.io/v1alpha1
+kind: Publication
+metadata:
+  name: autonomyx-stack-v0-1
+  namespace: default
+spec:
+  domain: platform
+  artifact: autonomyx-oam-stack
+  version: 0.1.0
+  immutable: true
+  effectiveFrom: "2026-06-24T00:00:00+05:30"
+  expiresAt: "2026-12-24T00:00:00+05:30"
+  certificationRef: autonomyx-stack-v0-1

--- a/autonomyx-stack/deploy/tls/webhook-tls-secret.example.yaml
+++ b/autonomyx-stack/deploy/tls/webhook-tls-secret.example.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: autonomyx-controller-webhook-tls
+  namespace: autonomyx-system
+type: kubernetes.io/tls
+stringData:
+  tls.crt: |
+    REPLACE_WITH_WEBHOOK_CERTIFICATE
+  tls.key: |
+    REPLACE_WITH_WEBHOOK_PRIVATE_KEY

--- a/autonomyx-stack/deploy/webhook.yaml
+++ b/autonomyx-stack/deploy/webhook.yaml
@@ -1,0 +1,26 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: autonomyx-gate
+webhooks:
+  - name: gate.autonomyx.io
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+    failurePolicy: Fail
+    rules:
+      - apiGroups: ["autonomyx.io"]
+        apiVersions: ["v1alpha1"]
+        operations: ["CREATE", "UPDATE"]
+        resources:
+          - autonomyxmanifests
+          - domains
+          - gates
+          - publications
+          - certifications
+    clientConfig:
+      service:
+        namespace: autonomyx-system
+        name: autonomyx-controller
+        path: /admit
+        port: 443
+      caBundle: "REPLACE_WITH_CA_BUNDLE"

--- a/autonomyx-stack/docs/kubernetes.md
+++ b/autonomyx-stack/docs/kubernetes.md
@@ -1,0 +1,71 @@
+# Autonomyx Kubernetes Layer
+
+This directory turns the Autonomyx OAM stack into Kubernetes-native resources.
+
+## Resource kinds
+
+- `AutonomyxManifest` — canonical binding contract for an app stack.
+- `Domain` — hard execution, visibility, and trust boundary.
+- `Gate` — deny-by-default policy enforcement object.
+- `Publication` — immutable artifact publication record.
+- `Certification` — provenance and supply-chain certification record.
+
+## Install CRDs
+
+```bash
+kubectl apply -f deploy/crds/
+```
+
+## Install controller resources
+
+```bash
+kubectl apply -f deploy/rbac.yaml
+kubectl apply -f deploy/controller.yaml
+```
+
+## Install webhook contract
+
+The webhook file contains a placeholder CA bundle.
+
+```bash
+# replace REPLACE_WITH_CA_BUNDLE first
+kubectl apply -f deploy/webhook.yaml
+```
+
+## Apply samples
+
+```bash
+kubectl apply -f deploy/samples/domain-platform.yaml
+kubectl apply -f deploy/samples/gate-default.yaml
+kubectl apply -f deploy/samples/certification-stack.yaml
+kubectl apply -f deploy/samples/publication-stack.yaml
+kubectl apply -f deploy/samples/manifest-stack.yaml
+```
+
+## Controller skeleton
+
+The current controller code is in:
+
+- `src/controller/reconciler.ts`
+- `src/controller/admission.ts`
+
+It does not yet run an HTTP server. The next implementation step is to expose `/admit`, verify TLS, and wire Kubernetes watches for each CRD.
+
+## Invariant mapping
+
+| Invariant | Kubernetes enforcement |
+| --- | --- |
+| Domain-bound execution | `Domain` CRD + required `spec.domain` on every object |
+| Every application is a gate | `Gate` CRD + validating webhook |
+| JIT access and authorization | Gate fields `jitAccess` and `jitAuthorization` |
+| Immutable publication | `Publication.spec.immutable == true` |
+| Supply-chain certification | `Certification` CRD with provenance digest |
+| Canonical manifest | `AutonomyxManifest` CRD |
+
+## Next hardening
+
+1. Add controller-runtime or lightweight HTTP server.
+2. Add OPA bundle evaluation for `policy/gate.rego`.
+3. Add SPIFFE/SPIRE identity extraction for admission requests.
+4. Add OpenTelemetry spans for every reconcile/admission decision.
+5. Add Sigstore/SLSA/SBOM verifier integration for `Certification`.

--- a/autonomyx-stack/docs/mvp.md
+++ b/autonomyx-stack/docs/mvp.md
@@ -8,10 +8,14 @@ The MVP is a usable control-plane surface for the Autonomyx OAM stack.
 - Health endpoint at `/healthz`
 - App registry endpoint at `/api/apps`
 - State endpoint at `/api/state`
+- Audit endpoint at `/api/audit`
 - Manifest endpoint at `/api/manifest`
 - Binding endpoint at `/api/binding`
 - Execution endpoint at `/api/execute`
+- Reset endpoint at `/api/reset`
 - Admission endpoint at `/admit`
+- File-backed state persistence
+- Optional bearer-token write protection
 
 ## Run locally
 
@@ -27,11 +31,24 @@ Open:
 http://localhost:8080
 ```
 
+## Run locally with token protection
+
+```bash
+AUTONOMYX_MVP_TOKEN=change-me npm run mvp:dev
+```
+
+Write requests must include:
+
+```text
+Authorization: Bearer change-me
+```
+
 ## Execute through API
 
 ```bash
 curl -X POST http://localhost:8080/api/execute \
   -H 'content-type: application/json' \
+  -H 'authorization: Bearer change-me' \
   -H 'x-oidc-subject: mvp-operator' \
   --data '{
     "domain": "platform",
@@ -43,6 +60,20 @@ curl -X POST http://localhost:8080/api/execute \
       "immutable": true
     }
   }'
+```
+
+## State persistence
+
+By default, MVP state is written to:
+
+```text
+./data/autonomyx-state.json
+```
+
+Override it with:
+
+```bash
+AUTONOMYX_STATE_FILE=/var/lib/autonomyx/state/autonomyx-state.json npm run mvp:dev
 ```
 
 ## Run in Kubernetes
@@ -58,6 +89,13 @@ Open:
 http://localhost:8080
 ```
 
+The Kubernetes MVP deployment includes:
+
+- `PersistentVolumeClaim` named `autonomyx-mvp-state`
+- `Secret` named `autonomyx-mvp-auth`
+- `AUTONOMYX_STATE_FILE=/var/lib/autonomyx/state/autonomyx-state.json`
+- `AUTONOMYX_MVP_TOKEN` loaded from the secret
+
 ## MVP scope
 
 This is the first usable product surface. It proves:
@@ -67,14 +105,14 @@ OAM apps
   → manifest
   → binding
   → execution API
-  → graph state
+  → persistent graph state
   → audit event
   → operator UI
 ```
 
 ## Not yet included
 
-- Persistent database
+- Production database adapter
 - Authentication login UI
 - Real OPA bundle runtime
 - Real SPIFFE Workload API

--- a/autonomyx-stack/docs/mvp.md
+++ b/autonomyx-stack/docs/mvp.md
@@ -1,0 +1,83 @@
+# Autonomyx MVP
+
+The MVP is a usable control-plane surface for the Autonomyx OAM stack.
+
+## What it provides
+
+- Browser operator UI at `/`
+- Health endpoint at `/healthz`
+- App registry endpoint at `/api/apps`
+- State endpoint at `/api/state`
+- Manifest endpoint at `/api/manifest`
+- Binding endpoint at `/api/binding`
+- Execution endpoint at `/api/execute`
+- Admission endpoint at `/admit`
+
+## Run locally
+
+```bash
+cd autonomyx-stack
+npm install
+npm run mvp:dev
+```
+
+Open:
+
+```text
+http://localhost:8080
+```
+
+## Execute through API
+
+```bash
+curl -X POST http://localhost:8080/api/execute \
+  -H 'content-type: application/json' \
+  -H 'x-oidc-subject: mvp-operator' \
+  --data '{
+    "domain": "platform",
+    "op": "⊕",
+    "payload": {
+      "@id": "publication:mvp-api",
+      "@type": "AutonomyxPublication",
+      "title": "MVP API Publication",
+      "immutable": true
+    }
+  }'
+```
+
+## Run in Kubernetes
+
+```bash
+kubectl apply -k deploy/
+kubectl -n autonomyx-system port-forward svc/autonomyx-mvp 8080:80
+```
+
+Open:
+
+```text
+http://localhost:8080
+```
+
+## MVP scope
+
+This is the first usable product surface. It proves:
+
+```text
+OAM apps
+  → manifest
+  → binding
+  → execution API
+  → graph state
+  → audit event
+  → operator UI
+```
+
+## Not yet included
+
+- Persistent database
+- Authentication login UI
+- Real OPA bundle runtime
+- Real SPIFFE Workload API
+- Real OpenTelemetry exporter
+- Real Sigstore/SLSA verification
+- Production TLS automation

--- a/autonomyx-stack/docs/mvp.md
+++ b/autonomyx-stack/docs/mvp.md
@@ -14,7 +14,8 @@ The MVP is a usable control-plane surface for the Autonomyx OAM stack.
 - Execution endpoint at `/api/execute`
 - Reset endpoint at `/api/reset`
 - Admission endpoint at `/admit`
-- File-backed state persistence
+- JSON-file state persistence
+- SurrealDB state persistence scaffold
 - Optional bearer-token write protection
 
 ## Run locally
@@ -64,7 +65,13 @@ curl -X POST http://localhost:8080/api/execute \
 
 ## State persistence
 
-By default, MVP state is written to:
+Default provider is JSON:
+
+```bash
+AUTONOMYX_STATE_PROVIDER=json npm run mvp:dev
+```
+
+By default, JSON state is written to:
 
 ```text
 ./data/autonomyx-state.json
@@ -74,6 +81,32 @@ Override it with:
 
 ```bash
 AUTONOMYX_STATE_FILE=/var/lib/autonomyx/state/autonomyx-state.json npm run mvp:dev
+```
+
+## SurrealDB provider
+
+Switch MVP state to SurrealDB:
+
+```bash
+AUTONOMYX_STATE_PROVIDER=surrealdb \
+SURREALDB_ENDPOINT=http://localhost:8000 \
+SURREALDB_NAMESPACE=agennext \
+SURREALDB_DATABASE=fabric \
+SURREALDB_USERNAME=root \
+SURREALDB_PASSWORD=root \
+npm run mvp:dev
+```
+
+The storage record defaults to:
+
+```text
+autonomyx_state:mvp
+```
+
+Override it with:
+
+```bash
+AUTONOMYX_STATE_RECORD_ID=autonomyx_state:prod
 ```
 
 ## Run in Kubernetes
@@ -93,7 +126,10 @@ The Kubernetes MVP deployment includes:
 
 - `PersistentVolumeClaim` named `autonomyx-mvp-state`
 - `Secret` named `autonomyx-mvp-auth`
+- `Secret` named `autonomyx-surrealdb-auth`
+- `AUTONOMYX_STATE_PROVIDER=json` by default
 - `AUTONOMYX_STATE_FILE=/var/lib/autonomyx/state/autonomyx-state.json`
+- SurrealDB env values ready for `surrealdb.fabric.svc.cluster.local:8000`
 - `AUTONOMYX_MVP_TOKEN` loaded from the secret
 
 ## MVP scope
@@ -112,7 +148,6 @@ OAM apps
 
 ## Not yet included
 
-- Production database adapter
 - Authentication login UI
 - Real OPA bundle runtime
 - Real SPIFFE Workload API

--- a/autonomyx-stack/docs/oam-mapping.md
+++ b/autonomyx-stack/docs/oam-mapping.md
@@ -1,0 +1,29 @@
+# Autonomyx OAM Mapping
+
+Autonomyx is pinned to the Open Application Model concept described in the CNCF article, with Autonomyx extensions for governance, certification, re-base, and graph state.
+
+## Canonical mapping
+
+| OAM primitive | Autonomyx primitive | Meaning |
+| --- | --- | --- |
+| Component | Publication | A deployable, immutable application capability. |
+| Trait | Policy | Operational behavior and governance controls. |
+| Scope | Domain | Execution, trust, and visibility boundary. |
+| Workflow | Execution Chain | Ordered or parallel runtime path. |
+| ApplicationConfiguration | autonomyx.manifest | Executable contract binding domain, identity, policy, graph, and certification. |
+
+## Build rule
+
+Every Autonomyx component is itself an OAM-style application. Each application is a gate: it exposes capabilities only through domain-bound, policy-governed, audited execution.
+
+## Stack tiers
+
+1. Foundation: domain, identity, policy, graph.
+2. Governance: trust, certification, audit.
+3. Runtime: execution, publication, discovery.
+4. OAM: OAM renderer and manifest contract.
+5. Experience: AutoDesk and centers for builder, graph, trust, policy, publish, certify.
+
+## Invariant
+
+No application bypasses domain, identity, policy, graph, audit, or certification. If it cannot be represented in `autonomyx.manifest`, it is not part of the platform.

--- a/autonomyx-stack/docs/runbook.md
+++ b/autonomyx-stack/docs/runbook.md
@@ -1,0 +1,110 @@
+# Autonomyx Operator Runbook
+
+This runbook binds the Autonomyx OAM stack from source to cluster.
+
+## 1. Build controller
+
+```bash
+cd autonomyx-stack
+npm install
+npm run build
+docker build -t ghcr.io/agennext/autonomyx-controller:0.1.0 .
+```
+
+## 2. Certify artifact before publication
+
+The current Certification verifier requires:
+
+- `subject`
+- `provenance.source`
+- `provenance.digest` beginning with `sha256:`
+- `provenance.sbomRef`
+- `provenance.signatureRef`
+- `validFrom`
+- `validUntil`
+
+Example:
+
+```yaml
+apiVersion: autonomyx.io/v1alpha1
+kind: Certification
+metadata:
+  name: autonomyx-stack-v0-1
+spec:
+  domain: platform
+  subject: ghcr.io/agennext/autonomyx-controller:0.1.0
+  provenance:
+    source: AGenNext/Agent-Platform
+    digest: sha256:REPLACE
+    sbomRef: sbom:REPLACE
+    signatureRef: cosign:REPLACE
+    slsaLevel: build-l1
+  validFrom: "2026-06-24T00:00:00+05:30"
+  validUntil: "2026-12-24T00:00:00+05:30"
+```
+
+## 3. Bind webhook TLS
+
+`deploy/webhook.yaml` contains `REPLACE_WITH_CA_BUNDLE`.
+
+Production binding options:
+
+1. cert-manager issued serving certificate.
+2. SPIRE/SPIFFE workload SVID converted for webhook serving cert flow.
+3. Manually generated cluster-local CA for first bootstrap only.
+
+The controller deployment must mount the serving certificate before using the Kubernetes webhook in production. The current local server is HTTP-first for scaffold testing.
+
+## 4. Apply stack
+
+```bash
+kubectl apply -k deploy/
+```
+
+## 5. Validate health
+
+```bash
+kubectl -n autonomyx-system get deploy autonomyx-controller
+kubectl -n autonomyx-system get svc autonomyx-controller
+```
+
+For local dev:
+
+```bash
+npm run controller:dev
+curl http://localhost:8443/healthz
+```
+
+## 6. Admission contract
+
+Every admission decision performs:
+
+```text
+headers/body
+  -> identity extraction
+  -> domain resolution
+  -> trust score
+  -> policy evaluation
+  -> CRD reconciliation
+  -> status patch
+  -> telemetry event
+```
+
+## 7. Break-glass policy
+
+Deletes are denied by policy scaffold with:
+
+```text
+DELETE_REQUIRES_EXPLICIT_BREAK_GLASS_POLICY
+```
+
+Add a separate break-glass CRD/policy before allowing delete paths.
+
+## 8. Next hardening
+
+- Real OPA bundle runtime instead of TypeScript mirror.
+- SPIFFE Workload API integration.
+- OpenTelemetry SDK exporter.
+- Sigstore verification implementation.
+- SLSA provenance parsing.
+- Kubernetes watch/reconcile loop.

--- a/autonomyx-stack/examples/admission-review.json
+++ b/autonomyx-stack/examples/admission-review.json
@@ -1,0 +1,29 @@
+{
+  "apiVersion": "admission.k8s.io/v1",
+  "kind": "AdmissionReview",
+  "request": {
+    "uid": "admission:example:001",
+    "operation": "CREATE",
+    "object": {
+      "apiVersion": "autonomyx.io/v1alpha1",
+      "kind": "Certification",
+      "metadata": {
+        "name": "autonomyx-stack-v0-1",
+        "namespace": "default"
+      },
+      "spec": {
+        "domain": "platform",
+        "subject": "ghcr.io/agennext/autonomyx-controller:0.1.0",
+        "provenance": {
+          "source": "AGenNext/Agent-Platform",
+          "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+          "sbomRef": "sbom:example",
+          "signatureRef": "cosign:example",
+          "slsaLevel": "build-l1"
+        },
+        "validFrom": "2026-06-24T00:00:00+05:30",
+        "validUntil": "2026-12-24T00:00:00+05:30"
+      }
+    }
+  }
+}

--- a/autonomyx-stack/examples/request.json
+++ b/autonomyx-stack/examples/request.json
@@ -1,0 +1,20 @@
+{
+  "id": "req:example:001",
+  "domain": "platform",
+  "identity": {
+    "id": "user:001",
+    "issuer": "local",
+    "subject": "operator",
+    "claims": {
+      "role": "platform-operator"
+    }
+  },
+  "op": "⊕",
+  "payload": {
+    "@id": "publication:example",
+    "@type": "AutonomyxPublication",
+    "title": "Example immutable publication",
+    "immutable": true,
+    "effectiveFrom": "2026-06-24T00:00:00+05:30"
+  }
+}

--- a/autonomyx-stack/package.json
+++ b/autonomyx-stack/package.json
@@ -10,7 +10,8 @@
     "dev": "tsx src/index.ts",
     "controller:dev": "tsx src/controller/server.ts",
     "controller:start": "node dist/controller/server.js",
-    "check": "tsc --noEmit -p tsconfig.json"
+    "check": "tsc --noEmit -p tsconfig.json",
+    "validate:stack": "node scripts/validate-stack.mjs"
   },
   "dependencies": {
     "zod": "^3.23.8"

--- a/autonomyx-stack/package.json
+++ b/autonomyx-stack/package.json
@@ -8,6 +8,8 @@
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
     "dev": "tsx src/index.ts",
+    "controller:dev": "tsx src/controller/server.ts",
+    "controller:start": "node dist/controller/server.js",
     "check": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {

--- a/autonomyx-stack/package.json
+++ b/autonomyx-stack/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@agennext/autonomyx-stack",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Autonomyx Open Application Governance Platform stack: domain-bound, policy-governed, graph-backed execution apps.",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts",
+    "check": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/autonomyx-stack/package.json
+++ b/autonomyx-stack/package.json
@@ -8,6 +8,8 @@
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
     "dev": "tsx src/index.ts",
+    "mvp:dev": "tsx src/mvp/server.ts",
+    "mvp:start": "node dist/mvp/server.js",
     "controller:dev": "tsx src/controller/server.ts",
     "controller:start": "node dist/controller/server.js",
     "check": "tsc --noEmit -p tsconfig.json",

--- a/autonomyx-stack/policy/gate.rego
+++ b/autonomyx-stack/policy/gate.rego
@@ -1,0 +1,24 @@
+package autonomyx.gate
+
+default allow := false
+
+allow if {
+  input.identity.id != ""
+  input.domain != "blocked"
+  input.trust_score >= 0.5
+}
+
+deny[reason] if {
+  input.identity.id == ""
+  reason := "IDENTITY_REQUIRED"
+}
+
+deny[reason] if {
+  input.domain == "blocked"
+  reason := "DOMAIN_BLOCKED"
+}
+
+deny[reason] if {
+  input.trust_score < 0.5
+  reason := "TRUST_BELOW_THRESHOLD"
+}

--- a/autonomyx-stack/scripts/validate-stack.mjs
+++ b/autonomyx-stack/scripts/validate-stack.mjs
@@ -23,6 +23,10 @@ const required = [
   "src/mvp/html.ts",
   "src/mvp/store.ts",
   "src/mvp/auth.ts",
+  "src/mvp/storage/types.ts",
+  "src/mvp/storage/index.ts",
+  "src/mvp/storage/json-store.ts",
+  "src/mvp/storage/surreal-store.ts",
   "src/security/identity.ts",
   "src/security/policy.ts",
   "src/security/certification.ts",
@@ -68,9 +72,9 @@ for (const route of ["/api/apps", "/api/state", "/api/audit", "/api/execute", "/
 }
 
 const deployment = fs.readFileSync(path.join(root, "deploy/mvp.yaml"), "utf8");
-for (const token of ["PersistentVolumeClaim", "AUTONOMYX_STATE_FILE", "AUTONOMYX_MVP_TOKEN"]) {
+for (const token of ["PersistentVolumeClaim", "AUTONOMYX_STATE_PROVIDER", "AUTONOMYX_STATE_FILE", "AUTONOMYX_MVP_TOKEN", "SURREALDB_ENDPOINT"]) {
   if (!deployment.includes(token)) {
-    console.error(`MVP deployment missing persistence/auth token: ${token}`);
+    console.error(`MVP deployment missing persistence/auth/storage token: ${token}`);
     process.exit(1);
   }
 }

--- a/autonomyx-stack/scripts/validate-stack.mjs
+++ b/autonomyx-stack/scripts/validate-stack.mjs
@@ -1,0 +1,57 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const required = [
+  "autonomyx.manifest.yaml",
+  "bindings/autonomyx.stack.binding.yaml",
+  "deploy/kustomization.yaml",
+  "deploy/crds/autonomyx.io_autonomyxmanifests.yaml",
+  "deploy/crds/autonomyx.io_domains.yaml",
+  "deploy/crds/autonomyx.io_gates.yaml",
+  "deploy/crds/autonomyx.io_publications.yaml",
+  "deploy/crds/autonomyx.io_certifications.yaml",
+  "deploy/rbac.yaml",
+  "deploy/controller.yaml",
+  "deploy/webhook.yaml",
+  "policy/gate.rego",
+  "src/controller/server.ts",
+  "src/controller/admission.ts",
+  "src/controller/reconciler.ts",
+  "src/security/identity.ts",
+  "src/security/policy.ts",
+  "src/security/certification.ts",
+  "src/observability/telemetry.ts",
+];
+
+const missing = required.filter((file) => !fs.existsSync(path.join(root, file)));
+if (missing.length > 0) {
+  console.error("Autonomyx stack validation failed. Missing files:");
+  for (const file of missing) console.error(`- ${file}`);
+  process.exit(1);
+}
+
+const manifest = fs.readFileSync(path.join(root, "autonomyx.manifest.yaml"), "utf8");
+for (const invariant of [
+  "rebaseAtEverySurface",
+  "eligibilityBeforeDiscovery",
+  "jitAccess",
+  "jitAuthorization",
+  "immutablePublication",
+  "everyApplicationIsGate",
+]) {
+  if (!manifest.includes(invariant)) {
+    console.error(`Autonomyx manifest missing invariant: ${invariant}`);
+    process.exit(1);
+  }
+}
+
+const binding = fs.readFileSync(path.join(root, "bindings/autonomyx.stack.binding.yaml"), "utf8");
+for (const bindingKey of ["domainBindings", "appBindings", "everyResourceHasDomain", "everyPublicationRequiresCertification"]) {
+  if (!binding.includes(bindingKey)) {
+    console.error(`Autonomyx binding missing: ${bindingKey}`);
+    process.exit(1);
+  }
+}
+
+console.log("Autonomyx stack validation passed.");

--- a/autonomyx-stack/scripts/validate-stack.mjs
+++ b/autonomyx-stack/scripts/validate-stack.mjs
@@ -21,6 +21,8 @@ const required = [
   "src/controller/reconciler.ts",
   "src/mvp/server.ts",
   "src/mvp/html.ts",
+  "src/mvp/store.ts",
+  "src/mvp/auth.ts",
   "src/security/identity.ts",
   "src/security/policy.ts",
   "src/security/certification.ts",
@@ -58,9 +60,17 @@ for (const bindingKey of ["domainBindings", "appBindings", "everyResourceHasDoma
 }
 
 const mvp = fs.readFileSync(path.join(root, "src/mvp/server.ts"), "utf8");
-for (const route of ["/api/apps", "/api/state", "/api/execute", "/api/manifest", "/api/binding"]) {
+for (const route of ["/api/apps", "/api/state", "/api/audit", "/api/execute", "/api/reset", "/api/manifest", "/api/binding"]) {
   if (!mvp.includes(route)) {
     console.error(`MVP server missing route: ${route}`);
+    process.exit(1);
+  }
+}
+
+const deployment = fs.readFileSync(path.join(root, "deploy/mvp.yaml"), "utf8");
+for (const token of ["PersistentVolumeClaim", "AUTONOMYX_STATE_FILE", "AUTONOMYX_MVP_TOKEN"]) {
+  if (!deployment.includes(token)) {
+    console.error(`MVP deployment missing persistence/auth token: ${token}`);
     process.exit(1);
   }
 }

--- a/autonomyx-stack/scripts/validate-stack.mjs
+++ b/autonomyx-stack/scripts/validate-stack.mjs
@@ -13,11 +13,14 @@ const required = [
   "deploy/crds/autonomyx.io_certifications.yaml",
   "deploy/rbac.yaml",
   "deploy/controller.yaml",
+  "deploy/mvp.yaml",
   "deploy/webhook.yaml",
   "policy/gate.rego",
   "src/controller/server.ts",
   "src/controller/admission.ts",
   "src/controller/reconciler.ts",
+  "src/mvp/server.ts",
+  "src/mvp/html.ts",
   "src/security/identity.ts",
   "src/security/policy.ts",
   "src/security/certification.ts",
@@ -50,6 +53,14 @@ const binding = fs.readFileSync(path.join(root, "bindings/autonomyx.stack.bindin
 for (const bindingKey of ["domainBindings", "appBindings", "everyResourceHasDomain", "everyPublicationRequiresCertification"]) {
   if (!binding.includes(bindingKey)) {
     console.error(`Autonomyx binding missing: ${bindingKey}`);
+    process.exit(1);
+  }
+}
+
+const mvp = fs.readFileSync(path.join(root, "src/mvp/server.ts"), "utf8");
+for (const route of ["/api/apps", "/api/state", "/api/execute", "/api/manifest", "/api/binding"]) {
+  if (!mvp.includes(route)) {
+    console.error(`MVP server missing route: ${route}`);
     process.exit(1);
   }
 }

--- a/autonomyx-stack/src/apps.ts
+++ b/autonomyx-stack/src/apps.ts
@@ -1,0 +1,99 @@
+import type { AutonomyxApp } from "./types.js";
+
+function app(
+  name: string,
+  tier: AutonomyxApp["tier"],
+  domain: string,
+  capabilities: AutonomyxApp["capabilities"],
+  traits: string[] = ["domain-bound", "gate-enforced", "audited"]
+): AutonomyxApp {
+  return {
+    name,
+    tier,
+    domain,
+    oam: {
+      component: name,
+      traits,
+      scopes: [domain],
+      workflows: [`${name}:rebase`, `${name}:authorize`, `${name}:execute`, `${name}:audit`],
+    },
+    capabilities,
+  };
+}
+
+export const foundationApps: AutonomyxApp[] = [
+  app("autonomyx-domain", "foundation", "platform", [
+    { name: "create-domain", method: "POST", path: "/domain", requires: ["identity", "policy"] },
+    { name: "get-domain", method: "GET", path: "/domain/:id", requires: ["identity"] },
+  ]),
+  app("autonomyx-identity", "foundation", "platform", [
+    { name: "resolve-identity", method: "POST", path: "/identity/resolve", requires: ["domain"] },
+    { name: "bind-workload", method: "POST", path: "/identity/workload", requires: ["domain", "policy"] },
+  ], ["spiffe", "oidc", "domain-bound", "audited"]),
+  app("autonomyx-policy", "foundation", "platform", [
+    { name: "evaluate-policy", method: "POST", path: "/policy/evaluate", requires: ["identity", "domain"] },
+    { name: "publish-policy", method: "POST", path: "/policy", requires: ["certification"] },
+  ], ["opa", "rego", "deny-by-default", "audited"]),
+  app("autonomyx-graph", "foundation", "platform", [
+    { name: "upsert-entity", method: "POST", path: "/graph/entity", requires: ["identity", "policy"] },
+    { name: "query-graph", method: "GET", path: "/graph", requires: ["eligibility"] },
+  ], ["json-ld", "schema-org", "single-state", "audited"]),
+];
+
+export const governanceApps: AutonomyxApp[] = [
+  app("autonomyx-trust", "governance", "governance", [
+    { name: "score-trust", method: "POST", path: "/trust/score", requires: ["identity", "graph", "audit"] },
+  ], ["trust-score", "risk", "eligibility"]),
+  app("autonomyx-certification", "governance", "governance", [
+    { name: "certify-artifact", method: "POST", path: "/certify", requires: ["provenance", "signature"] },
+    { name: "verify-provenance", method: "POST", path: "/verify", requires: ["artifact"] },
+  ], ["slsa", "sigstore", "sbom", "provenance"]),
+  app("autonomyx-audit", "governance", "governance", [
+    { name: "append-event", method: "POST", path: "/audit/events", requires: ["identity", "domain"] },
+    { name: "read-timeline", method: "GET", path: "/audit/timeline", requires: ["eligibility"] },
+  ], ["opentelemetry", "temporal", "immutable"]),
+];
+
+export const runtimeApps: AutonomyxApp[] = [
+  app("autonomyx-runtime", "runtime", "runtime", [
+    { name: "execute", method: "POST", path: "/execute", requires: ["domain", "identity", "policy", "graph"] },
+    { name: "run-workflow", method: "POST", path: "/workflow", requires: ["manifest"] },
+  ], ["rebase", "kernel", "wasm-ready", "gate-enforced"]),
+  app("autonomyx-publication", "runtime", "runtime", [
+    { name: "publish", method: "POST", path: "/publish", requires: ["certification", "audit"] },
+    { name: "version", method: "POST", path: "/version", requires: ["publication"] },
+  ], ["immutable", "versioned", "time-bound"]),
+  app("autonomyx-discovery", "runtime", "runtime", [
+    { name: "discover", method: "GET", path: "/discover", requires: ["eligibility", "trust"] },
+    { name: "catalog", method: "GET", path: "/catalog", requires: ["domain"] },
+  ], ["eligibility-before-discovery", "catalog", "registry"]),
+];
+
+export const oamApps: AutonomyxApp[] = [
+  app("autonomyx-oam", "oam", "platform", [
+    { name: "render-component", method: "POST", path: "/oam/component", requires: ["manifest"] },
+    { name: "bind-trait", method: "POST", path: "/oam/trait", requires: ["policy"] },
+  ], ["component", "trait", "scope", "workflow"]),
+  app("autonomyx-manifest", "oam", "platform", [
+    { name: "validate-manifest", method: "POST", path: "/manifest/validate", requires: ["domain", "policy"] },
+    { name: "emit-manifest", method: "POST", path: "/manifest", requires: ["certification"] },
+  ], ["canonical-contract", "domain-bound", "certified"]),
+];
+
+export const experienceApps: AutonomyxApp[] = [
+  app("autodesk", "experience", "workspace", [{ name: "open-workspace", method: "GET", path: "/desk", requires: ["identity", "domain"] }]),
+  app("autobuilder", "experience", "workspace", [{ name: "build-app", method: "POST", path: "/builder/app", requires: ["oam", "manifest"] }]),
+  app("autograph", "experience", "workspace", [{ name: "explore-graph", method: "GET", path: "/graph/explorer", requires: ["eligibility"] }]),
+  app("autotrust", "experience", "workspace", [{ name: "view-trust", method: "GET", path: "/trust/center", requires: ["trust"] }]),
+  app("autopolicy", "experience", "workspace", [{ name: "govern-policy", method: "POST", path: "/policy/center", requires: ["policy", "identity"] }]),
+  app("autopublish", "experience", "workspace", [{ name: "release", method: "POST", path: "/publish/center", requires: ["certification"] }]),
+  app("autocertify", "experience", "workspace", [{ name: "certify", method: "POST", path: "/certify/center", requires: ["audit", "provenance"] }]),
+];
+
+export const allApps: AutonomyxApp[] = [
+  ...foundationApps,
+  ...governanceApps,
+  ...runtimeApps,
+  ...oamApps,
+  ...experienceApps,
+];

--- a/autonomyx-stack/src/controller/admission.ts
+++ b/autonomyx-stack/src/controller/admission.ts
@@ -1,0 +1,59 @@
+import { reconcile, type KubernetesObject } from "./reconciler.js";
+
+export type AdmissionReview = {
+  request?: {
+    uid: string;
+    operation: "CREATE" | "UPDATE" | "DELETE" | "CONNECT";
+    object?: KubernetesObject;
+  };
+};
+
+export type AdmissionResponse = {
+  apiVersion: "admission.k8s.io/v1";
+  kind: "AdmissionReview";
+  response: {
+    uid: string;
+    allowed: boolean;
+    status?: { message: string };
+    patchType?: "JSONPatch";
+    patch?: string;
+  };
+};
+
+export function admit(review: AdmissionReview): AdmissionResponse {
+  const uid = review.request?.uid ?? "unknown";
+  const object = review.request?.object;
+
+  if (!object) {
+    return deny(uid, "Admission object missing");
+  }
+
+  const decision = reconcile(object);
+  if (decision.phase === "Rejected") {
+    return deny(uid, decision.reason ?? "Rejected by Autonomyx gate");
+  }
+
+  const patch = Buffer.from(JSON.stringify(decision.patches)).toString("base64");
+  return {
+    apiVersion: "admission.k8s.io/v1",
+    kind: "AdmissionReview",
+    response: {
+      uid,
+      allowed: true,
+      patchType: "JSONPatch",
+      patch,
+    },
+  };
+}
+
+function deny(uid: string, message: string): AdmissionResponse {
+  return {
+    apiVersion: "admission.k8s.io/v1",
+    kind: "AdmissionReview",
+    response: {
+      uid,
+      allowed: false,
+      status: { message },
+    },
+  };
+}

--- a/autonomyx-stack/src/controller/admission.ts
+++ b/autonomyx-stack/src/controller/admission.ts
@@ -1,3 +1,6 @@
+import { admissionTelemetry } from "../observability/telemetry.js";
+import { extractIdentity, type WorkloadIdentity } from "../security/identity.js";
+import { evaluatePolicy, trustForIdentity } from "../security/policy.js";
 import { reconcile, type KubernetesObject } from "./reconciler.js";
 
 export type AdmissionReview = {
@@ -5,6 +8,7 @@ export type AdmissionReview = {
     uid: string;
     operation: "CREATE" | "UPDATE" | "DELETE" | "CONNECT";
     object?: KubernetesObject;
+    userInfo?: Record<string, unknown>;
   };
 };
 
@@ -20,20 +24,54 @@ export type AdmissionResponse = {
   };
 };
 
-export function admit(review: AdmissionReview): AdmissionResponse {
+export function admit(
+  review: AdmissionReview,
+  headers: Record<string, string | string[] | undefined> = {}
+): AdmissionResponse {
   const uid = review.request?.uid ?? "unknown";
   const object = review.request?.object;
+  const identity = extractIdentity(headers, review as unknown as Record<string, unknown>);
 
   if (!object) {
-    return deny(uid, "Admission object missing");
+    return deny(uid, "Admission object missing", identity);
+  }
+
+  const domain = resolveDomain(object);
+  const trustScore = trustForIdentity(identity.id);
+  const policy = evaluatePolicy({
+    identity,
+    domain,
+    trustScore,
+    resourceKind: object.kind,
+    operation: review.request?.operation,
+    certified: Boolean(object.spec?.certificationRef),
+  });
+
+  if (!policy.allow) {
+    return deny(uid, policy.reasons.join(","), identity, object);
   }
 
   const decision = reconcile(object);
   if (decision.phase === "Rejected") {
-    return deny(uid, decision.reason ?? "Rejected by Autonomyx gate");
+    return deny(uid, decision.reason ?? "Rejected by Autonomyx gate", identity, object);
   }
 
-  const patch = Buffer.from(JSON.stringify(decision.patches)).toString("base64");
+  const patches = [
+    ...decision.patches,
+    { op: "add" as const, path: "/metadata/annotations/autonomyx.io~1identity", value: identity.id },
+    { op: "add" as const, path: "/metadata/annotations/autonomyx.io~1trust-score", value: String(trustScore) },
+    { op: "add" as const, path: "/metadata/annotations/autonomyx.io~1rebase", value: new Date().toISOString() },
+  ];
+
+  const patch = Buffer.from(JSON.stringify(patches)).toString("base64");
+  admissionTelemetry({
+    uid,
+    kind: object.kind,
+    name: object.metadata.name,
+    namespace: object.metadata.namespace,
+    allowed: true,
+  });
+
   return {
     apiVersion: "admission.k8s.io/v1",
     kind: "AdmissionReview",
@@ -46,14 +84,36 @@ export function admit(review: AdmissionReview): AdmissionResponse {
   };
 }
 
-function deny(uid: string, message: string): AdmissionResponse {
+function deny(
+  uid: string,
+  message: string,
+  identity?: WorkloadIdentity,
+  object?: KubernetesObject
+): AdmissionResponse {
+  admissionTelemetry({
+    uid,
+    kind: object?.kind,
+    name: object?.metadata.name,
+    namespace: object?.metadata.namespace,
+    allowed: false,
+    reason: message,
+  });
+
   return {
     apiVersion: "admission.k8s.io/v1",
     kind: "AdmissionReview",
     response: {
       uid,
       allowed: false,
-      status: { message },
+      status: { message: `${message}${identity ? ` identity=${identity.id}` : ""}` },
     },
   };
+}
+
+function resolveDomain(object: KubernetesObject): string {
+  const specDomain = object.spec?.domain;
+  if (typeof specDomain === "string" && specDomain.length > 0) return specDomain;
+  const metadataDomain = object.metadata.namespace;
+  if (metadataDomain) return metadataDomain;
+  return "blocked";
 }

--- a/autonomyx-stack/src/controller/reconciler.ts
+++ b/autonomyx-stack/src/controller/reconciler.ts
@@ -1,3 +1,5 @@
+import { verifyCertification } from "../security/certification.js";
+
 export type KubernetesObject = {
   apiVersion: string;
   kind: string;
@@ -58,21 +60,28 @@ function reconcilePublication(object: KubernetesObject): ReconcileDecision {
   if (!object.spec?.domain) return reject("Publication requires spec.domain");
   if (!object.spec?.artifact) return reject("Publication requires spec.artifact");
   if (object.spec.immutable !== true) return reject("Publication must be immutable");
-  return accept("Published", Boolean(object.spec.certificationRef));
+  if (!object.spec.certificationRef) return reject("Publication requires spec.certificationRef");
+  return accept("Published", true);
 }
 
 function reconcileCertification(object: KubernetesObject): ReconcileDecision {
-  const provenance = object.spec?.provenance as Record<string, unknown> | undefined;
+  const decision = verifyCertification({
+    subject: String(object.spec?.subject ?? ""),
+    provenance: object.spec?.provenance as Parameters<typeof verifyCertification>[0]["provenance"],
+    validFrom: typeof object.spec?.validFrom === "string" ? object.spec.validFrom : undefined,
+    validUntil: typeof object.spec?.validUntil === "string" ? object.spec.validUntil : undefined,
+  });
+
   if (!object.spec?.domain) return reject("Certification requires spec.domain");
-  if (!object.spec?.subject) return reject("Certification requires spec.subject");
-  if (!provenance?.source || !provenance?.digest) return reject("Certification requires provenance.source and provenance.digest");
+  if (!decision.certified) return reject(decision.reasons.join(","));
+
   return {
     phase: "Certified",
     certified: true,
     patches: [
       { op: "add", path: "/status/phase", value: "Certified" },
       { op: "add", path: "/status/certified", value: true },
-      { op: "add", path: "/status/trustScore", value: 0.8 },
+      { op: "add", path: "/status/trustScore", value: decision.trustScore },
     ],
   };
 }

--- a/autonomyx-stack/src/controller/reconciler.ts
+++ b/autonomyx-stack/src/controller/reconciler.ts
@@ -1,0 +1,102 @@
+export type KubernetesObject = {
+  apiVersion: string;
+  kind: string;
+  metadata: {
+    name: string;
+    namespace?: string;
+    generation?: number;
+  };
+  spec?: Record<string, unknown>;
+  status?: Record<string, unknown>;
+};
+
+export type ReconcileDecision = {
+  phase: "Accepted" | "Rejected" | "Certified" | "Published" | "Pending";
+  certified?: boolean;
+  reason?: string;
+  patches: Array<{ op: "add" | "replace"; path: string; value: unknown }>;
+};
+
+export function reconcile(object: KubernetesObject): ReconcileDecision {
+  switch (object.kind) {
+    case "AutonomyxManifest":
+      return reconcileManifest(object);
+    case "Domain":
+      return reconcileDomain(object);
+    case "Gate":
+      return reconcileGate(object);
+    case "Publication":
+      return reconcilePublication(object);
+    case "Certification":
+      return reconcileCertification(object);
+    default:
+      return reject(`Unsupported kind: ${object.kind}`);
+  }
+}
+
+function reconcileManifest(object: KubernetesObject): ReconcileDecision {
+  const domain = object.spec?.domain;
+  const apps = object.spec?.apps;
+  if (typeof domain !== "string" || domain.length === 0) return reject("Manifest requires spec.domain");
+  if (!Array.isArray(apps) || apps.length === 0) return reject("Manifest requires at least one app");
+  return accept("Accepted", true);
+}
+
+function reconcileDomain(object: KubernetesObject): ReconcileDecision {
+  if (!object.spec?.name) return reject("Domain requires spec.name");
+  if (!object.spec?.scope) return reject("Domain requires spec.scope");
+  return accept("Accepted", object.spec.status === "verified");
+}
+
+function reconcileGate(object: KubernetesObject): ReconcileDecision {
+  if (!object.spec?.domain) return reject("Gate requires spec.domain");
+  if (object.spec.mode !== "deny-by-default") return reject("Gate mode must be deny-by-default");
+  return accept("Accepted", false);
+}
+
+function reconcilePublication(object: KubernetesObject): ReconcileDecision {
+  if (!object.spec?.domain) return reject("Publication requires spec.domain");
+  if (!object.spec?.artifact) return reject("Publication requires spec.artifact");
+  if (object.spec.immutable !== true) return reject("Publication must be immutable");
+  return accept("Published", Boolean(object.spec.certificationRef));
+}
+
+function reconcileCertification(object: KubernetesObject): ReconcileDecision {
+  const provenance = object.spec?.provenance as Record<string, unknown> | undefined;
+  if (!object.spec?.domain) return reject("Certification requires spec.domain");
+  if (!object.spec?.subject) return reject("Certification requires spec.subject");
+  if (!provenance?.source || !provenance?.digest) return reject("Certification requires provenance.source and provenance.digest");
+  return {
+    phase: "Certified",
+    certified: true,
+    patches: [
+      { op: "add", path: "/status/phase", value: "Certified" },
+      { op: "add", path: "/status/certified", value: true },
+      { op: "add", path: "/status/trustScore", value: 0.8 },
+    ],
+  };
+}
+
+function accept(phase: ReconcileDecision["phase"], certified: boolean): ReconcileDecision {
+  return {
+    phase,
+    certified,
+    patches: [
+      { op: "add", path: "/status/phase", value: phase },
+      { op: "add", path: "/status/certified", value: certified },
+    ],
+  };
+}
+
+function reject(reason: string): ReconcileDecision {
+  return {
+    phase: "Rejected",
+    certified: false,
+    reason,
+    patches: [
+      { op: "add", path: "/status/phase", value: "Rejected" },
+      { op: "add", path: "/status/certified", value: false },
+      { op: "add", path: "/status/message", value: reason },
+    ],
+  };
+}

--- a/autonomyx-stack/src/controller/server.ts
+++ b/autonomyx-stack/src/controller/server.ts
@@ -31,7 +31,7 @@ const server = createServer(async (request, response) => {
   try {
     const body = await readBody(request);
     const review = JSON.parse(body) as AdmissionReview;
-    const decision = admit(review);
+    const decision = admit(review, request.headers);
     response.writeHead(200, { "content-type": "application/json" });
     response.end(JSON.stringify(decision));
   } catch (error) {

--- a/autonomyx-stack/src/controller/server.ts
+++ b/autonomyx-stack/src/controller/server.ts
@@ -1,0 +1,46 @@
+import { createServer } from "node:http";
+import { admit, type AdmissionReview } from "./admission.js";
+
+const port = Number(process.env.PORT ?? process.env.AUTONOMYX_WEBHOOK_PORT ?? 8443);
+
+function readBody(request: NodeJS.ReadableStream): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let body = "";
+    request.setEncoding("utf8");
+    request.on("data", (chunk) => {
+      body += chunk;
+    });
+    request.on("end", () => resolve(body));
+    request.on("error", reject);
+  });
+}
+
+const server = createServer(async (request, response) => {
+  if (request.method === "GET" && request.url === "/healthz") {
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify({ status: "ok", service: "autonomyx-controller" }));
+    return;
+  }
+
+  if (request.method !== "POST" || request.url !== "/admit") {
+    response.writeHead(404, { "content-type": "application/json" });
+    response.end(JSON.stringify({ error: "not_found" }));
+    return;
+  }
+
+  try {
+    const body = await readBody(request);
+    const review = JSON.parse(body) as AdmissionReview;
+    const decision = admit(review);
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify(decision));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "unknown error";
+    response.writeHead(400, { "content-type": "application/json" });
+    response.end(JSON.stringify({ error: "invalid_admission_review", message }));
+  }
+});
+
+server.listen(port, "0.0.0.0", () => {
+  console.log(`autonomyx-controller listening on :${port}`);
+});

--- a/autonomyx-stack/src/index.ts
+++ b/autonomyx-stack/src/index.ts
@@ -1,0 +1,28 @@
+import { listApplications, runPlatform, initialState } from "./platform.js";
+import type { ExecutionRequest } from "./types.js";
+
+const state = initialState();
+
+console.log("Autonomyx OAM Stack Apps");
+console.table(listApplications());
+
+const request: ExecutionRequest = {
+  id: `req:${Date.now()}`,
+  domain: "platform",
+  identity: {
+    id: "user:001",
+    issuer: "local",
+    subject: "operator",
+    claims: { role: "platform-operator" },
+  },
+  op: "⊕",
+  payload: {
+    "@id": "publication:autonomyx-stack-v0.1",
+    "@type": "AutonomyxPublication",
+    title: "Autonomyx OAM Stack v0.1",
+    immutable: true,
+  },
+};
+
+const next = runPlatform(request, state);
+console.log(JSON.stringify({ graphVersion: next.graph.version, lastAudit: next.audit.at(-1) }, null, 2));

--- a/autonomyx-stack/src/kernel.ts
+++ b/autonomyx-stack/src/kernel.ts
@@ -1,0 +1,115 @@
+import type {
+  AnyDataGraph,
+  AuditEvent,
+  ExecutionRequest,
+  ExecutionResult,
+  GraphNode,
+  PlatformState,
+} from "./types.js";
+
+export function rebase(state: PlatformState, request: ExecutionRequest): PlatformState {
+  const domain = state.domains.find((item) => item.id === request.domain);
+  if (!domain) {
+    throw new Error(`Domain not found: ${request.domain}`);
+  }
+  return structuredClone(state);
+}
+
+export function gate(state: PlatformState, request: ExecutionRequest): { allow: boolean; reason?: string } {
+  const domain = state.domains.find((item) => item.id === request.domain);
+  if (!domain) return { allow: false, reason: "DOMAIN_NOT_FOUND" };
+  if (domain.status === "suspended") return { allow: false, reason: "DOMAIN_SUSPENDED" };
+  if (!request.identity?.id) return { allow: false, reason: "IDENTITY_REQUIRED" };
+
+  const trustScore = state.trust[request.identity.id] ?? 0;
+  if (trustScore < 0.5) return { allow: false, reason: "TRUST_BELOW_THRESHOLD" };
+
+  return { allow: true };
+}
+
+export function arithmetic(graph: AnyDataGraph, request: ExecutionRequest): AnyDataGraph {
+  const next = structuredClone(graph);
+
+  switch (request.op) {
+    case "⊕": {
+      const node: GraphNode = {
+        "@id": String(request.payload["@id"] ?? `node:${request.id}`),
+        "@type": String(request.payload["@type"] ?? "AutonomyxArtifact"),
+        domain: request.domain,
+        data: request.payload,
+        createdAt: new Date().toISOString(),
+      };
+      next.nodes.push(node);
+      next.version += 1;
+      return next;
+    }
+
+    case "⊖": {
+      const target = request.target ?? String(request.payload["@id"] ?? "");
+      next.nodes = next.nodes.filter((node) => node["@id"] !== target || node.domain !== request.domain);
+      next.edges = next.edges.filter((edge) => edge.from !== target && edge.to !== target);
+      next.version += 1;
+      return next;
+    }
+
+    case "⊗": {
+      const target = request.target ?? String(request.payload["@id"] ?? "");
+      const factor = Number(request.payload.factor ?? 1);
+      next.edges = next.edges.map((edge) => {
+        if (edge.domain !== request.domain) return edge;
+        if (target && edge.from !== target && edge.to !== target) return edge;
+        return { ...edge, weight: (edge.weight ?? 1) * factor };
+      });
+      next.version += 1;
+      return next;
+    }
+
+    case "÷": {
+      const scope = String(request.payload.scope ?? request.domain);
+      next.nodes.push({
+        "@id": `scope:${request.domain}:${scope}`,
+        "@type": "AutonomyxDomainScope",
+        domain: request.domain,
+        data: { scope, source: request.id },
+        createdAt: new Date().toISOString(),
+      });
+      next.version += 1;
+      return next;
+    }
+  }
+}
+
+export function auditEvent(request: ExecutionRequest, status: AuditEvent["status"], graphVersion: number, reason?: string): AuditEvent {
+  return {
+    id: `audit:${request.id}`,
+    requestId: request.id,
+    identity: request.identity.id,
+    domain: request.domain,
+    op: request.op,
+    status,
+    reason,
+    graphVersion,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+export function execute(state: PlatformState, request: ExecutionRequest): ExecutionResult {
+  let rebased: PlatformState;
+  try {
+    rebased = rebase(state, request);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : "REBASE_FAILED";
+    const auditEventResult = auditEvent(request, "error", state.graph.version, reason);
+    return { status: "error", reason, graph: state.graph, auditEvent: auditEventResult };
+  }
+
+  const decision = gate(rebased, request);
+  if (!decision.allow) {
+    const auditEventResult = auditEvent(request, "denied", rebased.graph.version, decision.reason);
+    return { status: "denied", reason: decision.reason, graph: rebased.graph, auditEvent: auditEventResult };
+  }
+
+  const graph = arithmetic(rebased.graph, request);
+  const auditEventResult = auditEvent(request, "allowed", graph.version);
+  return { status: "allowed", graph, auditEvent: auditEventResult };
+}

--- a/autonomyx-stack/src/mvp/auth.ts
+++ b/autonomyx-stack/src/mvp/auth.ts
@@ -1,0 +1,17 @@
+import type { IncomingHttpHeaders } from "node:http";
+
+const token = process.env.AUTONOMYX_MVP_TOKEN;
+
+export function isAuthRequired(): boolean {
+  return Boolean(token);
+}
+
+export function authorize(headers: IncomingHttpHeaders): { allowed: boolean; reason?: string } {
+  if (!token) return { allowed: true };
+
+  const authorization = headers.authorization;
+  const expected = `Bearer ${token}`;
+
+  if (authorization === expected) return { allowed: true };
+  return { allowed: false, reason: "MVP_TOKEN_REQUIRED" };
+}

--- a/autonomyx-stack/src/mvp/html.ts
+++ b/autonomyx-stack/src/mvp/html.ts
@@ -1,0 +1,73 @@
+export function renderMvpHtml(): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Autonomyx MVP</title>
+  <style>
+    :root { color-scheme: light dark; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    body { margin: 0; background: #f7f9fc; color: #101828; }
+    header { padding: 28px 32px; background: #0f172a; color: white; }
+    main { padding: 28px 32px; display: grid; gap: 20px; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); }
+    h1 { margin: 0 0 8px; font-size: 28px; }
+    h2 { margin-top: 0; }
+    .card { background: white; border: 1px solid #e5e7eb; border-radius: 16px; padding: 20px; box-shadow: 0 8px 24px rgba(15, 23, 42, 0.06); }
+    code, pre { background: #0f172a; color: #d1e7ff; border-radius: 10px; padding: 12px; overflow: auto; }
+    button { background: #0f172a; color: white; border: 0; border-radius: 10px; padding: 10px 14px; cursor: pointer; }
+    input, textarea, select { width: 100%; box-sizing: border-box; border: 1px solid #d0d5dd; border-radius: 10px; padding: 10px; margin: 6px 0 12px; }
+    .ok { color: #027a48; font-weight: 700; }
+    .bad { color: #b42318; font-weight: 700; }
+    @media (prefers-color-scheme: dark) { body { background: #020617; color: #e5e7eb; } .card { background: #0f172a; border-color: #1e293b; } }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Autonomyx MVP Control Plane</h1>
+    <div>Domain-bound · policy-governed · graph-backed · certified execution</div>
+  </header>
+  <main>
+    <section class="card">
+      <h2>Health</h2>
+      <p id="health">Loading...</p>
+      <button onclick="loadHealth()">Refresh</button>
+    </section>
+    <section class="card">
+      <h2>Stack Apps</h2>
+      <pre id="apps">Loading...</pre>
+      <button onclick="loadApps()">Refresh</button>
+    </section>
+    <section class="card">
+      <h2>Execute</h2>
+      <label>Domain</label>
+      <input id="domain" value="platform" />
+      <label>Operation</label>
+      <select id="op"><option>⊕</option><option>⊖</option><option>⊗</option><option>÷</option></select>
+      <label>Payload JSON</label>
+      <textarea id="payload" rows="8">{"@id":"publication:mvp","@type":"AutonomyxPublication","title":"MVP publication","immutable":true}</textarea>
+      <button onclick="execute()">Run</button>
+      <pre id="executeResult"></pre>
+    </section>
+    <section class="card">
+      <h2>State</h2>
+      <pre id="state">Loading...</pre>
+      <button onclick="loadState()">Refresh</button>
+    </section>
+  </main>
+<script>
+async function getJson(path) { const res = await fetch(path); return res.json(); }
+async function loadHealth() { const data = await getJson('/healthz'); document.getElementById('health').innerHTML = data.status === 'ok' ? '<span class="ok">ok</span>' : '<span class="bad">bad</span>'; }
+async function loadApps() { document.getElementById('apps').textContent = JSON.stringify(await getJson('/api/apps'), null, 2); }
+async function loadState() { document.getElementById('state').textContent = JSON.stringify(await getJson('/api/state'), null, 2); }
+async function execute() {
+  const payload = JSON.parse(document.getElementById('payload').value);
+  const body = { domain: document.getElementById('domain').value, op: document.getElementById('op').value, payload };
+  const res = await fetch('/api/execute', { method: 'POST', headers: { 'content-type': 'application/json', 'x-oidc-subject': 'mvp-operator' }, body: JSON.stringify(body) });
+  document.getElementById('executeResult').textContent = JSON.stringify(await res.json(), null, 2);
+  await loadState();
+}
+loadHealth(); loadApps(); loadState();
+</script>
+</body>
+</html>`;
+}

--- a/autonomyx-stack/src/mvp/server.ts
+++ b/autonomyx-stack/src/mvp/server.ts
@@ -6,10 +6,10 @@ import { initialState, listApplications, runPlatform } from "../platform.js";
 import type { ExecutionRequest, PlatformState } from "../types.js";
 import { authorize, isAuthRequired } from "./auth.js";
 import { renderMvpHtml } from "./html.js";
-import { loadState, saveState, statePath } from "./store.js";
+import { loadState, saveState, stateInfo } from "./store.js";
 
 const port = Number(process.env.PORT ?? process.env.AUTONOMYX_MVP_PORT ?? 8080);
-let state: PlatformState = loadState();
+let state: PlatformState;
 
 function json(response: ServerResponse, code: number, value: unknown): void {
   response.writeHead(code, { "content-type": "application/json" });
@@ -56,7 +56,7 @@ const server = createServer(async (request, response) => {
       version: "0.1.0",
       authRequired: isAuthRequired(),
       graphVersion: state.graph.version,
-      statePath: statePath(),
+      storage: stateInfo(),
     });
     return;
   }
@@ -80,6 +80,7 @@ const server = createServer(async (request, response) => {
       graphVersion: state.graph.version,
       nodes: state.graph.nodes.length,
       edges: state.graph.edges.length,
+      storage: stateInfo(),
       audit: state.audit.slice(-10),
     });
     return;
@@ -121,8 +122,8 @@ const server = createServer(async (request, response) => {
         context: body.context,
       };
       state = runPlatform(execution, state);
-      saveState(state);
-      json(response, 200, { ok: true, requestId, graphVersion: state.graph.version, audit: state.audit.at(-1) });
+      await saveState(state);
+      json(response, 200, { ok: true, requestId, graphVersion: state.graph.version, audit: state.audit.at(-1), storage: stateInfo() });
     } catch (error) {
       const message = error instanceof Error ? error.message : "invalid request";
       json(response, 400, { ok: false, error: message });
@@ -132,8 +133,8 @@ const server = createServer(async (request, response) => {
 
   if (request.method === "POST" && url.pathname === "/api/reset") {
     state = initialState();
-    saveState(state);
-    json(response, 200, { ok: true, graphVersion: state.graph.version });
+    await saveState(state);
+    json(response, 200, { ok: true, graphVersion: state.graph.version, storage: stateInfo() });
     return;
   }
 
@@ -151,6 +152,8 @@ const server = createServer(async (request, response) => {
   json(response, 404, { error: "not_found" });
 });
 
+state = await loadState();
 server.listen(port, "0.0.0.0", () => {
   console.log(`autonomyx MVP listening on :${port}`);
+  console.log(JSON.stringify({ storage: stateInfo() }));
 });

--- a/autonomyx-stack/src/mvp/server.ts
+++ b/autonomyx-stack/src/mvp/server.ts
@@ -1,20 +1,22 @@
-import { createServer } from "node:http";
+import { createServer, type ServerResponse } from "node:http";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { admit, type AdmissionReview } from "../controller/admission.js";
 import { initialState, listApplications, runPlatform } from "../platform.js";
 import type { ExecutionRequest, PlatformState } from "../types.js";
+import { authorize, isAuthRequired } from "./auth.js";
 import { renderMvpHtml } from "./html.js";
+import { loadState, saveState, statePath } from "./store.js";
 
 const port = Number(process.env.PORT ?? process.env.AUTONOMYX_MVP_PORT ?? 8080);
-let state: PlatformState = initialState();
+let state: PlatformState = loadState();
 
-function json(response: Parameters<typeof createServer>[0] extends (...args: infer A) => unknown ? A[1] : never, code: number, value: unknown): void {
+function json(response: ServerResponse, code: number, value: unknown): void {
   response.writeHead(code, { "content-type": "application/json" });
   response.end(JSON.stringify(value, null, 2));
 }
 
-function text(response: Parameters<typeof createServer>[0] extends (...args: infer A) => unknown ? A[1] : never, code: number, value: string, type = "text/plain"): void {
+function text(response: ServerResponse, code: number, value: string, type = "text/plain"): void {
   response.writeHead(code, { "content-type": type });
   response.end(value);
 }
@@ -48,8 +50,23 @@ const server = createServer(async (request, response) => {
   }
 
   if (request.method === "GET" && url.pathname === "/healthz") {
-    json(response, 200, { status: "ok", service: "autonomyx-mvp", graphVersion: state.graph.version });
+    json(response, 200, {
+      status: "ok",
+      service: "autonomyx-mvp",
+      version: "0.1.0",
+      authRequired: isAuthRequired(),
+      graphVersion: state.graph.version,
+      statePath: statePath(),
+    });
     return;
+  }
+
+  if (url.pathname.startsWith("/api/") && request.method !== "GET") {
+    const auth = authorize(request.headers);
+    if (!auth.allowed) {
+      json(response, 401, { ok: false, error: auth.reason });
+      return;
+    }
   }
 
   if (request.method === "GET" && url.pathname === "/api/apps") {
@@ -65,6 +82,11 @@ const server = createServer(async (request, response) => {
       edges: state.graph.edges.length,
       audit: state.audit.slice(-10),
     });
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname === "/api/audit") {
+    json(response, 200, { count: state.audit.length, events: state.audit });
     return;
   }
 
@@ -99,11 +121,19 @@ const server = createServer(async (request, response) => {
         context: body.context,
       };
       state = runPlatform(execution, state);
+      saveState(state);
       json(response, 200, { ok: true, requestId, graphVersion: state.graph.version, audit: state.audit.at(-1) });
     } catch (error) {
       const message = error instanceof Error ? error.message : "invalid request";
       json(response, 400, { ok: false, error: message });
     }
+    return;
+  }
+
+  if (request.method === "POST" && url.pathname === "/api/reset") {
+    state = initialState();
+    saveState(state);
+    json(response, 200, { ok: true, graphVersion: state.graph.version });
     return;
   }
 

--- a/autonomyx-stack/src/mvp/server.ts
+++ b/autonomyx-stack/src/mvp/server.ts
@@ -1,0 +1,126 @@
+import { createServer } from "node:http";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { admit, type AdmissionReview } from "../controller/admission.js";
+import { initialState, listApplications, runPlatform } from "../platform.js";
+import type { ExecutionRequest, PlatformState } from "../types.js";
+import { renderMvpHtml } from "./html.js";
+
+const port = Number(process.env.PORT ?? process.env.AUTONOMYX_MVP_PORT ?? 8080);
+let state: PlatformState = initialState();
+
+function json(response: Parameters<typeof createServer>[0] extends (...args: infer A) => unknown ? A[1] : never, code: number, value: unknown): void {
+  response.writeHead(code, { "content-type": "application/json" });
+  response.end(JSON.stringify(value, null, 2));
+}
+
+function text(response: Parameters<typeof createServer>[0] extends (...args: infer A) => unknown ? A[1] : never, code: number, value: string, type = "text/plain"): void {
+  response.writeHead(code, { "content-type": type });
+  response.end(value);
+}
+
+function readBody(request: NodeJS.ReadableStream): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let body = "";
+    request.setEncoding("utf8");
+    request.on("data", (chunk) => {
+      body += chunk;
+    });
+    request.on("end", () => resolve(body));
+    request.on("error", reject);
+  });
+}
+
+function readJsonFile(path: string): string {
+  try {
+    return readFileSync(join(process.cwd(), path), "utf8");
+  } catch {
+    return "";
+  }
+}
+
+const server = createServer(async (request, response) => {
+  const url = new URL(request.url ?? "/", `http://${request.headers.host ?? "localhost"}`);
+
+  if (request.method === "GET" && url.pathname === "/") {
+    text(response, 200, renderMvpHtml(), "text/html");
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname === "/healthz") {
+    json(response, 200, { status: "ok", service: "autonomyx-mvp", graphVersion: state.graph.version });
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname === "/api/apps") {
+    json(response, 200, listApplications());
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname === "/api/state") {
+    json(response, 200, {
+      domains: state.domains,
+      graphVersion: state.graph.version,
+      nodes: state.graph.nodes.length,
+      edges: state.graph.edges.length,
+      audit: state.audit.slice(-10),
+    });
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname === "/api/manifest") {
+    text(response, 200, readJsonFile("autonomyx.manifest.yaml"), "text/yaml");
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname === "/api/binding") {
+    text(response, 200, readJsonFile("bindings/autonomyx.stack.binding.yaml"), "text/yaml");
+    return;
+  }
+
+  if (request.method === "POST" && url.pathname === "/api/execute") {
+    try {
+      const body = JSON.parse(await readBody(request)) as Partial<ExecutionRequest>;
+      const requestId = `req:${Date.now()}`;
+      const identityHeader = request.headers["x-spiffe-id"] ?? request.headers["x-oidc-subject"] ?? "mvp-operator";
+      const identitySubject = Array.isArray(identityHeader) ? identityHeader[0] : identityHeader;
+      const execution: ExecutionRequest = {
+        id: requestId,
+        domain: String(body.domain ?? "platform"),
+        identity: {
+          id: String(identitySubject).startsWith("spiffe://") ? String(identitySubject) : `oidc:${identitySubject}`,
+          issuer: String(identitySubject).startsWith("spiffe://") ? "spiffe" : "oidc",
+          subject: String(identitySubject),
+          claims: { source: "mvp-api" },
+        },
+        op: (body.op ?? "⊕") as ExecutionRequest["op"],
+        target: body.target,
+        payload: body.payload ?? {},
+        context: body.context,
+      };
+      state = runPlatform(execution, state);
+      json(response, 200, { ok: true, requestId, graphVersion: state.graph.version, audit: state.audit.at(-1) });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "invalid request";
+      json(response, 400, { ok: false, error: message });
+    }
+    return;
+  }
+
+  if (request.method === "POST" && url.pathname === "/admit") {
+    try {
+      const review = JSON.parse(await readBody(request)) as AdmissionReview;
+      json(response, 200, admit(review, request.headers));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "invalid admission review";
+      json(response, 400, { error: message });
+    }
+    return;
+  }
+
+  json(response, 404, { error: "not_found" });
+});
+
+server.listen(port, "0.0.0.0", () => {
+  console.log(`autonomyx MVP listening on :${port}`);
+});

--- a/autonomyx-stack/src/mvp/storage/index.ts
+++ b/autonomyx-stack/src/mvp/storage/index.ts
@@ -1,0 +1,20 @@
+import type { StateStore, StorageProviderName } from "./types.js";
+import { JsonStateStore } from "./json-store.js";
+import { SurrealStateStore } from "./surreal-store.js";
+
+export function createStateStore(): StateStore {
+  const provider = (process.env.AUTONOMYX_STATE_PROVIDER ?? "json") as StorageProviderName;
+
+  if (provider === "surrealdb") {
+    return new SurrealStateStore({
+      endpoint: process.env.SURREALDB_ENDPOINT ?? "http://surrealdb.fabric.svc.cluster.local:8000",
+      namespace: process.env.SURREALDB_NAMESPACE ?? "agennext",
+      database: process.env.SURREALDB_DATABASE ?? "fabric",
+      username: process.env.SURREALDB_USERNAME,
+      password: process.env.SURREALDB_PASSWORD,
+      recordId: process.env.AUTONOMYX_STATE_RECORD_ID,
+    });
+  }
+
+  return new JsonStateStore(process.env.AUTONOMYX_STATE_FILE ?? "./data/autonomyx-state.json");
+}

--- a/autonomyx-stack/src/mvp/storage/json-store.ts
+++ b/autonomyx-stack/src/mvp/storage/json-store.ts
@@ -1,0 +1,34 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { initialState } from "../../platform.js";
+import type { PlatformState } from "../../types.js";
+import type { StateStore } from "./types.js";
+
+export class JsonStateStore implements StateStore {
+  readonly name = "json" as const;
+
+  constructor(private readonly path: string) {}
+
+  async load(): Promise<PlatformState> {
+    if (!existsSync(this.path)) {
+      const state = initialState();
+      await this.save(state);
+      return state;
+    }
+
+    const raw = readFileSync(this.path, "utf8");
+    return JSON.parse(raw) as PlatformState;
+  }
+
+  async save(state: PlatformState): Promise<void> {
+    mkdirSync(dirname(this.path), { recursive: true });
+    writeFileSync(this.path, JSON.stringify(state, null, 2));
+  }
+
+  info(): Record<string, string | number | boolean | undefined> {
+    return {
+      provider: this.name,
+      path: this.path,
+    };
+  }
+}

--- a/autonomyx-stack/src/mvp/storage/surreal-store.ts
+++ b/autonomyx-stack/src/mvp/storage/surreal-store.ts
@@ -1,0 +1,76 @@
+import { initialState } from "../../platform.js";
+import type { PlatformState } from "../../types.js";
+import type { StateStore } from "./types.js";
+
+export type SurrealStateStoreConfig = {
+  endpoint: string;
+  namespace: string;
+  database: string;
+  username?: string;
+  password?: string;
+  recordId?: string;
+};
+
+export class SurrealStateStore implements StateStore {
+  readonly name = "surrealdb" as const;
+  private readonly recordId: string;
+
+  constructor(private readonly config: SurrealStateStoreConfig) {
+    this.recordId = config.recordId ?? "autonomyx_state:mvp";
+  }
+
+  async load(): Promise<PlatformState> {
+    const result = await this.query<[PlatformState]>(`SELECT * FROM ${this.recordId};`);
+    const existing = Array.isArray(result) ? result[0] : undefined;
+    if (existing) return existing;
+
+    const state = initialState();
+    await this.save(state);
+    return state;
+  }
+
+  async save(state: PlatformState): Promise<void> {
+    await this.query(`UPSERT ${this.recordId} CONTENT ${JSON.stringify(state)};`);
+  }
+
+  info(): Record<string, string | number | boolean | undefined> {
+    return {
+      provider: this.name,
+      endpoint: this.config.endpoint,
+      namespace: this.config.namespace,
+      database: this.config.database,
+      recordId: this.recordId,
+    };
+  }
+
+  private async query<T>(query: string): Promise<T> {
+    const headers: Record<string, string> = {
+      accept: "application/json",
+      "content-type": "application/surrealql",
+      ns: this.config.namespace,
+      db: this.config.database,
+    };
+
+    if (this.config.username && this.config.password) {
+      headers.authorization = `Basic ${Buffer.from(`${this.config.username}:${this.config.password}`).toString("base64")}`;
+    }
+
+    const response = await fetch(`${this.config.endpoint.replace(/\/$/, "")}/sql`, {
+      method: "POST",
+      headers,
+      body: query,
+    });
+
+    if (!response.ok) {
+      throw new Error(`SurrealDB query failed: ${response.status} ${response.statusText}`);
+    }
+
+    const json = (await response.json()) as Array<{ status: string; result?: unknown; detail?: string }>;
+    const first = json[0];
+    if (!first || first.status !== "OK") {
+      throw new Error(first?.detail ?? "SurrealDB query failed");
+    }
+
+    return first.result as T;
+  }
+}

--- a/autonomyx-stack/src/mvp/storage/types.ts
+++ b/autonomyx-stack/src/mvp/storage/types.ts
@@ -1,0 +1,10 @@
+import type { PlatformState } from "../../types.js";
+
+export type StorageProviderName = "json" | "surrealdb";
+
+export interface StateStore {
+  name: StorageProviderName;
+  load(): Promise<PlatformState>;
+  save(state: PlatformState): Promise<void>;
+  info(): Record<string, string | number | boolean | undefined>;
+}

--- a/autonomyx-stack/src/mvp/store.ts
+++ b/autonomyx-stack/src/mvp/store.ts
@@ -1,26 +1,16 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname } from "node:path";
-import { initialState } from "../platform.js";
 import type { PlatformState } from "../types.js";
+import { createStateStore } from "./storage/index.js";
 
-const defaultStatePath = process.env.AUTONOMYX_STATE_FILE ?? "./data/autonomyx-state.json";
+const store = createStateStore();
 
-export function loadState(path = defaultStatePath): PlatformState {
-  if (!existsSync(path)) {
-    const state = initialState();
-    saveState(state, path);
-    return state;
-  }
-
-  const raw = readFileSync(path, "utf8");
-  return JSON.parse(raw) as PlatformState;
+export async function loadState(): Promise<PlatformState> {
+  return store.load();
 }
 
-export function saveState(state: PlatformState, path = defaultStatePath): void {
-  mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, JSON.stringify(state, null, 2));
+export async function saveState(state: PlatformState): Promise<void> {
+  await store.save(state);
 }
 
-export function statePath(): string {
-  return defaultStatePath;
+export function stateInfo(): Record<string, string | number | boolean | undefined> {
+  return store.info();
 }

--- a/autonomyx-stack/src/mvp/store.ts
+++ b/autonomyx-stack/src/mvp/store.ts
@@ -1,0 +1,26 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { initialState } from "../platform.js";
+import type { PlatformState } from "../types.js";
+
+const defaultStatePath = process.env.AUTONOMYX_STATE_FILE ?? "./data/autonomyx-state.json";
+
+export function loadState(path = defaultStatePath): PlatformState {
+  if (!existsSync(path)) {
+    const state = initialState();
+    saveState(state, path);
+    return state;
+  }
+
+  const raw = readFileSync(path, "utf8");
+  return JSON.parse(raw) as PlatformState;
+}
+
+export function saveState(state: PlatformState, path = defaultStatePath): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(state, null, 2));
+}
+
+export function statePath(): string {
+  return defaultStatePath;
+}

--- a/autonomyx-stack/src/observability/telemetry.ts
+++ b/autonomyx-stack/src/observability/telemetry.ts
@@ -1,0 +1,38 @@
+export type TelemetryEvent = {
+  name: string;
+  timestamp: string;
+  attributes: Record<string, string | number | boolean | undefined>;
+};
+
+export function emitTelemetry(event: Omit<TelemetryEvent, "timestamp">): TelemetryEvent {
+  const record: TelemetryEvent = {
+    ...event,
+    timestamp: new Date().toISOString(),
+  };
+
+  // First implementation writes structured events to stdout.
+  // Production binding should export this through OpenTelemetry SDK + collector.
+  console.log(JSON.stringify({ telemetry: record }));
+  return record;
+}
+
+export function admissionTelemetry(input: {
+  uid: string;
+  kind?: string;
+  name?: string;
+  namespace?: string;
+  allowed: boolean;
+  reason?: string;
+}): TelemetryEvent {
+  return emitTelemetry({
+    name: "autonomyx.admission.decision",
+    attributes: {
+      uid: input.uid,
+      kind: input.kind,
+      name: input.name,
+      namespace: input.namespace,
+      allowed: input.allowed,
+      reason: input.reason,
+    },
+  });
+}

--- a/autonomyx-stack/src/platform.ts
+++ b/autonomyx-stack/src/platform.ts
@@ -1,0 +1,64 @@
+import { allApps } from "./apps.js";
+import { execute } from "./kernel.js";
+import type { ExecutionRequest, PlatformState } from "./types.js";
+
+export function initialState(): PlatformState {
+  return {
+    domains: [
+      { id: "platform", name: "Platform", scope: "foundation", status: "verified" },
+      { id: "governance", name: "Governance", scope: "governance", status: "verified" },
+      { id: "runtime", name: "Runtime", scope: "runtime", status: "verified" },
+      { id: "workspace", name: "Workspace", scope: "experience", status: "trusted" },
+    ],
+    graph: {
+      nodes: allApps.map((app) => ({
+        "@id": `app:${app.name}`,
+        "@type": "AutonomyxOAMApplication",
+        domain: app.domain,
+        data: {
+          name: app.name,
+          tier: app.tier,
+          oam: app.oam,
+          capabilities: app.capabilities,
+        },
+        createdAt: new Date().toISOString(),
+      })),
+      edges: allApps.flatMap((app) =>
+        app.capabilities.flatMap((capability) =>
+          capability.requires.map((requirement) => ({
+            from: `app:${app.name}`,
+            to: `capability:${requirement}`,
+            relation: "requires",
+            domain: app.domain,
+            weight: 1,
+          }))
+        )
+      ),
+      version: 1,
+    },
+    trust: {
+      "identity:system": 1,
+      "identity:operator": 0.9,
+      "user:001": 0.9,
+    },
+    audit: [],
+  };
+}
+
+export function runPlatform(request: ExecutionRequest, state: PlatformState = initialState()): PlatformState {
+  const result = execute(state, request);
+  return {
+    ...state,
+    graph: result.graph,
+    audit: [...state.audit, result.auditEvent],
+  };
+}
+
+export function listApplications() {
+  return allApps.map((app) => ({
+    name: app.name,
+    tier: app.tier,
+    domain: app.domain,
+    capabilities: app.capabilities.map((capability) => capability.name),
+  }));
+}

--- a/autonomyx-stack/src/security/certification.ts
+++ b/autonomyx-stack/src/security/certification.ts
@@ -1,0 +1,40 @@
+export type CertificationInput = {
+  subject: string;
+  provenance?: {
+    source?: string;
+    digest?: string;
+    sbomRef?: string;
+    signatureRef?: string;
+    slsaLevel?: string;
+  };
+  validFrom?: string;
+  validUntil?: string;
+};
+
+export type CertificationDecision = {
+  certified: boolean;
+  trustScore: number;
+  reasons: string[];
+};
+
+export function verifyCertification(input: CertificationInput): CertificationDecision {
+  const reasons: string[] = [];
+
+  if (!input.subject) reasons.push("SUBJECT_REQUIRED");
+  if (!input.provenance?.source) reasons.push("PROVENANCE_SOURCE_REQUIRED");
+  if (!input.provenance?.digest) reasons.push("PROVENANCE_DIGEST_REQUIRED");
+  if (!String(input.provenance?.digest ?? "").startsWith("sha256:")) reasons.push("DIGEST_MUST_BE_SHA256");
+  if (!input.provenance?.sbomRef) reasons.push("SBOM_REFERENCE_REQUIRED");
+  if (!input.provenance?.signatureRef) reasons.push("SIGNATURE_REFERENCE_REQUIRED");
+
+  const now = Date.now();
+  if (input.validFrom && Date.parse(input.validFrom) > now) reasons.push("CERTIFICATION_NOT_YET_VALID");
+  if (input.validUntil && Date.parse(input.validUntil) < now) reasons.push("CERTIFICATION_EXPIRED");
+
+  const certified = reasons.length === 0;
+  return {
+    certified,
+    trustScore: certified ? 0.85 : 0.25,
+    reasons,
+  };
+}

--- a/autonomyx-stack/src/security/identity.ts
+++ b/autonomyx-stack/src/security/identity.ts
@@ -1,0 +1,64 @@
+export type WorkloadIdentity = {
+  id: string;
+  issuer: "spiffe" | "oidc" | "kubernetes" | "unknown";
+  subject: string;
+  domain?: string;
+  raw?: Record<string, unknown>;
+};
+
+export function extractIdentity(headers: Record<string, string | string[] | undefined>, body?: Record<string, unknown>): WorkloadIdentity {
+  const spiffeId = header(headers, "x-spiffe-id");
+  if (spiffeId) {
+    return {
+      id: spiffeId,
+      issuer: "spiffe",
+      subject: spiffeId,
+      domain: header(headers, "x-autonomyx-domain"),
+      raw: { headers: safeHeaders(headers), body },
+    };
+  }
+
+  const oidcSubject = header(headers, "x-oidc-subject") ?? header(headers, "x-forwarded-user");
+  if (oidcSubject) {
+    return {
+      id: `oidc:${oidcSubject}`,
+      issuer: "oidc",
+      subject: oidcSubject,
+      domain: header(headers, "x-autonomyx-domain"),
+      raw: { headers: safeHeaders(headers), body },
+    };
+  }
+
+  const k8sUser = String((body?.request as Record<string, unknown> | undefined)?.userInfo ?? "");
+  if (k8sUser && k8sUser !== "[object Object]") {
+    return {
+      id: `kubernetes:${k8sUser}`,
+      issuer: "kubernetes",
+      subject: k8sUser,
+      domain: header(headers, "x-autonomyx-domain"),
+      raw: { headers: safeHeaders(headers), body },
+    };
+  }
+
+  return {
+    id: "unknown",
+    issuer: "unknown",
+    subject: "unknown",
+    domain: header(headers, "x-autonomyx-domain"),
+    raw: { headers: safeHeaders(headers), body },
+  };
+}
+
+function header(headers: Record<string, string | string[] | undefined>, key: string): string | undefined {
+  const lower = key.toLowerCase();
+  const value = headers[lower] ?? headers[key];
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+function safeHeaders(headers: Record<string, string | string[] | undefined>): Record<string, string | string[] | undefined> {
+  const copy = { ...headers };
+  delete copy.authorization;
+  delete copy.cookie;
+  return copy;
+}

--- a/autonomyx-stack/src/security/policy.ts
+++ b/autonomyx-stack/src/security/policy.ts
@@ -1,0 +1,42 @@
+export type PolicyInput = {
+  identity: { id: string; issuer?: string };
+  domain: string;
+  trustScore: number;
+  resourceKind?: string;
+  operation?: string;
+  certified?: boolean;
+};
+
+export type PolicyDecision = {
+  allow: boolean;
+  reasons: string[];
+};
+
+export function evaluatePolicy(input: PolicyInput): PolicyDecision {
+  const reasons: string[] = [];
+
+  if (!input.identity?.id || input.identity.id === "unknown") reasons.push("IDENTITY_REQUIRED");
+  if (!input.domain || input.domain === "blocked") reasons.push("DOMAIN_INVALID");
+  if (input.trustScore < 0.5) reasons.push("TRUST_BELOW_THRESHOLD");
+
+  if (input.resourceKind === "Publication" && input.certified !== true) {
+    reasons.push("PUBLICATION_REQUIRES_CERTIFICATION");
+  }
+
+  if (input.operation === "DELETE") {
+    reasons.push("DELETE_REQUIRES_EXPLICIT_BREAK_GLASS_POLICY");
+  }
+
+  return {
+    allow: reasons.length === 0,
+    reasons,
+  };
+}
+
+export function trustForIdentity(identityId: string): number {
+  if (identityId.startsWith("spiffe://")) return 0.9;
+  if (identityId.startsWith("oidc:")) return 0.75;
+  if (identityId.startsWith("kubernetes:")) return 0.65;
+  if (identityId === "unknown") return 0;
+  return 0.5;
+}

--- a/autonomyx-stack/src/types.ts
+++ b/autonomyx-stack/src/types.ts
@@ -1,0 +1,99 @@
+export type DomainId = string;
+export type IdentityId = string;
+export type TrustScore = number;
+
+export type ArithmeticOperator = "⊕" | "⊖" | "⊗" | "÷";
+
+export type OamKind = "Component" | "Trait" | "Scope" | "Workflow" | "ApplicationConfiguration";
+
+export interface Identity {
+  id: IdentityId;
+  issuer: "enterprise-iam" | "spiffe" | "oidc" | "local";
+  subject: string;
+  claims: Record<string, unknown>;
+}
+
+export interface Domain {
+  id: DomainId;
+  name: string;
+  scope: "foundation" | "governance" | "runtime" | "oam" | "experience";
+  status: "trusted" | "verified" | "suspended";
+}
+
+export interface GraphNode {
+  "@id": string;
+  "@type": string;
+  domain: DomainId;
+  data: Record<string, unknown>;
+  createdAt: string;
+}
+
+export interface GraphEdge {
+  from: string;
+  to: string;
+  relation: string;
+  domain: DomainId;
+  weight?: number;
+}
+
+export interface AnyDataGraph {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  version: number;
+}
+
+export interface ExecutionRequest {
+  id: string;
+  domain: DomainId;
+  identity: Identity;
+  op: ArithmeticOperator;
+  target?: string;
+  payload: Record<string, unknown>;
+  context?: Record<string, unknown>;
+}
+
+export interface ExecutionResult {
+  status: "allowed" | "denied" | "error";
+  reason?: string;
+  graph: AnyDataGraph;
+  auditEvent: AuditEvent;
+}
+
+export interface AuditEvent {
+  id: string;
+  requestId: string;
+  identity: IdentityId;
+  domain: DomainId;
+  op: ArithmeticOperator;
+  status: "allowed" | "denied" | "error";
+  reason?: string;
+  graphVersion: number;
+  timestamp: string;
+}
+
+export interface PlatformState {
+  domains: Domain[];
+  graph: AnyDataGraph;
+  trust: Record<string, TrustScore>;
+  audit: AuditEvent[];
+}
+
+export interface AppCapability {
+  name: string;
+  method: "GET" | "POST";
+  path: string;
+  requires: string[];
+}
+
+export interface AutonomyxApp {
+  name: string;
+  tier: "foundation" | "governance" | "runtime" | "oam" | "experience";
+  domain: DomainId;
+  oam: {
+    component: string;
+    traits: string[];
+    scopes: string[];
+    workflows: string[];
+  };
+  capabilities: AppCapability[];
+}

--- a/autonomyx-stack/tsconfig.json
+++ b/autonomyx-stack/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Builds the first-pass Autonomyx OAM stack and turns it into a runnable MVP control plane under `autonomyx-stack/`.

## MVP added

The MVP provides:

- browser operator UI at `/`
- health endpoint at `/healthz`
- app registry at `/api/apps`
- state view at `/api/state`
- manifest view at `/api/manifest`
- binding view at `/api/binding`
- execution endpoint at `/api/execute`
- admission endpoint at `/admit`

MVP files:
- `src/mvp/server.ts`
- `src/mvp/html.ts`
- `deploy/mvp.yaml`
- `docs/mvp.md`

## Kubernetes layer

CRDs:
- `AutonomyxManifest`
- `Domain`
- `Gate`
- `Publication`
- `Certification`

Controller/admission:
- `src/controller/reconciler.ts`
- `src/controller/admission.ts`
- `src/controller/server.ts`
- `GET /healthz`
- `POST /admit`

Security/observability:
- `src/security/identity.ts`
- `src/security/policy.ts`
- `src/security/certification.ts`
- `src/observability/telemetry.ts`

Install/binding manifests:
- `deploy/kustomization.yaml`
- `deploy/rbac.yaml`
- `deploy/controller.yaml`
- `deploy/mvp.yaml`
- `deploy/webhook.yaml`
- `deploy/tls/webhook-tls-secret.example.yaml`
- `deploy/samples/*`
- `bindings/autonomyx.stack.binding.yaml`

Delivery:
- `Dockerfile`
- `scripts/validate-stack.mjs`
- workflow validates stack, builds TypeScript, and exercises image build

Docs:
- `docs/kubernetes.md`
- `docs/runbook.md`
- `docs/mvp.md`

## Stack apps included

Foundation:
- autonomyx-domain
- autonomyx-identity
- autonomyx-policy
- autonomyx-graph

Governance:
- autonomyx-trust
- autonomyx-certification
- autonomyx-audit

Runtime:
- autonomyx-runtime
- autonomyx-publication
- autonomyx-discovery

OAM:
- autonomyx-oam
- autonomyx-manifest

Experience:
- autodesk
- autobuilder
- autograph
- autotrust
- autopolicy
- autopublish
- autocertify

## Run MVP

```bash
cd autonomyx-stack
npm install
npm run mvp:dev
```

Open `http://localhost:8080`.

## Run in Kubernetes

```bash
kubectl apply -k deploy/
kubectl -n autonomyx-system port-forward svc/autonomyx-mvp 8080:80
```

## Notes

This is now a runnable MVP control plane plus a Kubernetes-native resource model, admission endpoint, Dockerfile, binding contract, TLS secret mount, validation script, and image build workflow. It is not yet production-grade persistence/auth/TLS automation/live watches/real OPA runtime/OpenTelemetry SDK/SPIFFE API/Sigstore implementation.