### PR TITLE
Bootstrap internal Agent Console scaffold - superseded by Agent-Console split

### DIFF
--- a/internal-agent-console/README.md
+++ b/internal-agent-console/README.md
@@ -1,0 +1,147 @@
+# Internal Agent Console
+
+A fast internal hPanel-style console for AGenNext operations.
+
+This is **not** a hosting product and not a public control panel. It is an internal operator console that gives a simple UI over Kubernetes so the team can create workspaces, deploy agents, view logs, manage secrets, and operate the stack without exposing raw YAML.
+
+## Principle
+
+```text
+User clicks button
+  ↓
+Console API validates request
+  ↓
+Kubernetes API applies resources
+  ↓
+k3s runs the workload
+```
+
+Kubernetes remains the control plane. The console is a thin operational layer.
+
+## Initial Scope
+
+Build only the internal loop first:
+
+- Dashboard
+- Workspaces
+- Agents
+- Deployments
+- Logs
+- Secrets
+- Settings
+
+Skip for now:
+
+- Crossplane
+- Billing
+- Marketplace
+- Public reseller features
+- Email hosting
+- Full multi-tenant SaaS packaging
+
+## Stack
+
+```text
+Frontend  : Next.js + Tailwind
+Backend   : Spring Boot
+Runtime   : k3s / Kubernetes API
+Deploy    : Helm chart
+Database  : optional SurrealDB later
+Auth      : local admin first, Authentik later
+```
+
+## Repository Layout
+
+```text
+internal-agent-console/
+├── apps/
+│   ├── web/       # Next.js UI scaffold
+│   └── api/       # Spring Boot API scaffold
+├── charts/
+│   └── agent-console/
+├── deploy/
+├── docs/
+└── examples/
+```
+
+## First Use Case
+
+### Create Workspace
+
+A workspace maps to a Kubernetes namespace.
+
+```json
+{
+  "name": "research",
+  "description": "Internal research workspace"
+}
+```
+
+Creates:
+
+```text
+Namespace: research
+Labels: agennext.io/workspace=true
+```
+
+### Create Agent
+
+An agent maps to a Deployment, Service, ConfigMap, and Secret references.
+
+```json
+{
+  "name": "research-agent",
+  "workspace": "research",
+  "image": "ghcr.io/agennext/research-agent:latest",
+  "replicas": 1
+}
+```
+
+Creates:
+
+```text
+Deployment/research-agent
+Service/research-agent
+ConfigMap/research-agent-config
+```
+
+## Local Development
+
+```bash
+cd internal-agent-console/apps/web
+npm install
+npm run dev
+```
+
+```bash
+cd internal-agent-console/apps/api
+./mvnw spring-boot:run
+```
+
+## Deploy
+
+```bash
+helm upgrade --install agent-console ./internal-agent-console/charts/agent-console \
+  --namespace agent-console \
+  --create-namespace
+```
+
+## Security Defaults
+
+- Internal network only
+- No public ingress by default
+- Namespace-per-workspace
+- Least-privilege service account
+- Secrets mounted from Kubernetes Secrets
+- Audit every create/update/delete action
+
+## Roadmap
+
+1. Dashboard and read-only Kubernetes inventory
+2. Workspace create/delete
+3. Agent create/delete/restart/logs
+4. Secrets manager
+5. Helm template installer
+6. Authentik integration
+7. OPA policy gates
+8. SurrealDB audit/event store

--- a/internal-agent-console/apps/api/Containerfile
+++ b/internal-agent-console/apps/api/Containerfile
@@ -1,0 +1,11 @@
+FROM maven:3.9-eclipse-temurin-21 AS build
+WORKDIR /workspace
+COPY pom.xml ./
+COPY src ./src
+RUN mvn -q -DskipTests package
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=build /workspace/target/internal-agent-console-api-0.1.0.jar /app/app.jar
+EXPOSE 8080
+CMD java -jar /app/app.jar

--- a/internal-agent-console/apps/api/Dockerfile
+++ b/internal-agent-console/apps/api/Dockerfile
@@ -1,0 +1,11 @@
+FROM eclipse-temurin:21-jdk AS build
+WORKDIR /workspace
+COPY pom.xml ./
+COPY src ./src
+RUN ./mvnw -q -DskipTests package || mvn -q -DskipTests package
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=build /workspace/target/internal-agent-console-api-0.1.0.jar /app/app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/internal-agent-console/apps/api/pom.xml
+++ b/internal-agent-console/apps/api/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.3.4</version>
+    <relativePath/>
+  </parent>
+
+  <groupId>io.agennext</groupId>
+  <artifactId>internal-agent-console-api</artifactId>
+  <version>0.1.0</version>
+  <name>internal-agent-console-api</name>
+  <description>Internal hPanel-style console API for AGenNext</description>
+
+  <properties>
+    <java.version>21</java.version>
+    <kubernetes-client.version>6.13.4</kubernetes-client.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client</artifactId>
+      <version>${kubernetes-client.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/internal-agent-console/apps/api/src/main/java/io/agennext/console/ConsoleApiApplication.java
+++ b/internal-agent-console/apps/api/src/main/java/io/agennext/console/ConsoleApiApplication.java
@@ -1,0 +1,11 @@
+package io.agennext.console;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ConsoleApiApplication {
+  public static void main(String[] args) {
+    SpringApplication.run(ConsoleApiApplication.class, args);
+  }
+}

--- a/internal-agent-console/apps/api/src/main/java/io/agennext/console/api/AgentController.java
+++ b/internal-agent-console/apps/api/src/main/java/io/agennext/console/api/AgentController.java
@@ -1,0 +1,61 @@
+package io.agennext.console.api;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import java.util.List;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/agents")
+public class AgentController {
+
+  @GetMapping
+  public List<Map<String, Object>> list() {
+    return List.of(
+        Map.of("name", "research-agent", "workspace", "research", "image", "ghcr.io/agennext/research-agent:latest", "status", "running"),
+        Map.of("name", "ops-agent", "workspace", "ops", "image", "ghcr.io/agennext/ops-agent:latest", "status", "running")
+    );
+  }
+
+  @PostMapping
+  @ResponseStatus(HttpStatus.ACCEPTED)
+  public Map<String, Object> create(@Valid @RequestBody CreateAgentRequest request) {
+    return Map.of(
+        "accepted", true,
+        "operation", "deploy-agent",
+        "workspace", request.workspace(),
+        "name", request.name(),
+        "image", request.image(),
+        "replicas", request.replicas()
+    );
+  }
+
+  @PostMapping("/{workspace}/{name}/restart")
+  @ResponseStatus(HttpStatus.ACCEPTED)
+  public Map<String, Object> restart(@PathVariable String workspace, @PathVariable String name) {
+    return Map.of("accepted", true, "operation", "restart-agent", "workspace", workspace, "name", name);
+  }
+
+  @DeleteMapping("/{workspace}/{name}")
+  @ResponseStatus(HttpStatus.ACCEPTED)
+  public Map<String, Object> delete(@PathVariable String workspace, @PathVariable String name) {
+    return Map.of("accepted", true, "operation", "delete-agent", "workspace", workspace, "name", name);
+  }
+
+  public record CreateAgentRequest(
+      @NotBlank String name,
+      @NotBlank String workspace,
+      @NotBlank String image,
+      @Positive int replicas
+  ) {}
+}

--- a/internal-agent-console/apps/api/src/main/java/io/agennext/console/api/DashboardController.java
+++ b/internal-agent-console/apps/api/src/main/java/io/agennext/console/api/DashboardController.java
@@ -1,0 +1,23 @@
+package io.agennext.console.api;
+
+import java.util.Map;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/dashboard")
+public class DashboardController {
+
+  @GetMapping
+  public Map<String, Object> dashboard() {
+    return Map.of(
+        "workspaces", 3,
+        "agents", 12,
+        "deployments", 9,
+        "secrets", 6,
+        "cluster", "connected",
+        "mode", "internal-only"
+    );
+  }
+}

--- a/internal-agent-console/apps/api/src/main/java/io/agennext/console/api/WorkspaceController.java
+++ b/internal-agent-console/apps/api/src/main/java/io/agennext/console/api/WorkspaceController.java
@@ -1,0 +1,51 @@
+package io.agennext.console.api;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/workspaces")
+public class WorkspaceController {
+
+  @GetMapping
+  public List<Map<String, Object>> list() {
+    return List.of(
+        Map.of("name", "research", "namespace", "research", "status", "active"),
+        Map.of("name", "ops", "namespace", "ops", "status", "active")
+    );
+  }
+
+  @PostMapping
+  @ResponseStatus(HttpStatus.ACCEPTED)
+  public Map<String, Object> create(@Valid @RequestBody CreateWorkspaceRequest request) {
+    return Map.of(
+        "accepted", true,
+        "operation", "create-workspace",
+        "namespace", request.name(),
+        "next", "apply Namespace with agennext.io/managed-by=internal-agent-console"
+    );
+  }
+
+  @DeleteMapping("/{name}")
+  @ResponseStatus(HttpStatus.ACCEPTED)
+  public Map<String, Object> delete(@PathVariable String name) {
+    return Map.of(
+        "accepted", true,
+        "operation", "delete-workspace",
+        "namespace", name
+    );
+  }
+
+  public record CreateWorkspaceRequest(@NotBlank String name, String description) {}
+}

--- a/internal-agent-console/apps/web/.dockerignore
+++ b/internal-agent-console/apps/web/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+.next
+.git
+.env
+.env.local
+npm-debug.log

--- a/internal-agent-console/apps/web/app/globals.css
+++ b/internal-agent-console/apps/web/app/globals.css
@@ -1,0 +1,12 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}

--- a/internal-agent-console/apps/web/app/layout.tsx
+++ b/internal-agent-console/apps/web/app/layout.tsx
@@ -1,0 +1,14 @@
+import './globals.css';
+
+export const metadata = {
+  title: 'AGenNext Internal Agent Console',
+  description: 'Internal hPanel-style control panel for AGenNext operations',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/internal-agent-console/apps/web/app/page.tsx
+++ b/internal-agent-console/apps/web/app/page.tsx
@@ -1,0 +1,91 @@
+import { Boxes, Bot, Database, KeyRound, Server, ShieldCheck } from 'lucide-react';
+
+const stats = [
+  { label: 'Workspaces', value: '3', icon: Boxes },
+  { label: 'Agents', value: '12', icon: Bot },
+  { label: 'Deployments', value: '9', icon: Server },
+  { label: 'Secrets', value: '6', icon: KeyRound },
+];
+
+const actions = [
+  'Create Workspace',
+  'Deploy Agent',
+  'View Logs',
+  'Add Secret',
+  'Restart Deployment',
+  'Check Policy',
+];
+
+export default function Page() {
+  return (
+    <main className="min-h-screen bg-slate-950 text-slate-100">
+      <aside className="fixed inset-y-0 left-0 w-64 border-r border-slate-800 bg-slate-950 p-6">
+        <div className="text-xl font-semibold">AGenNext Console</div>
+        <div className="mt-1 text-sm text-slate-400">Internal control panel</div>
+        <nav className="mt-10 space-y-2 text-sm">
+          {['Dashboard', 'Workspaces', 'Agents', 'Deployments', 'Logs', 'Secrets', 'Settings'].map((item) => (
+            <a key={item} className="block rounded-lg px-3 py-2 text-slate-300 hover:bg-slate-900 hover:text-white" href="#">
+              {item}
+            </a>
+          ))}
+        </nav>
+      </aside>
+
+      <section className="ml-64 p-8">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight">Internal Agent Console</h1>
+            <p className="mt-2 text-slate-400">hPanel-style operations for workspaces, agents, secrets, and deployments.</p>
+          </div>
+          <button className="rounded-lg bg-white px-4 py-2 text-sm font-medium text-slate-950">Create Agent</button>
+        </div>
+
+        <div className="mt-8 grid grid-cols-4 gap-4">
+          {stats.map((stat) => {
+            const Icon = stat.icon;
+            return (
+              <div key={stat.label} className="rounded-2xl border border-slate-800 bg-slate-900 p-5">
+                <div className="flex items-center justify-between text-slate-400">
+                  <span className="text-sm">{stat.label}</span>
+                  <Icon className="h-5 w-5" />
+                </div>
+                <div className="mt-4 text-3xl font-semibold">{stat.value}</div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="mt-8 grid grid-cols-3 gap-6">
+          <div className="col-span-2 rounded-2xl border border-slate-800 bg-slate-900 p-6">
+            <h2 className="text-lg font-semibold">Quick Actions</h2>
+            <div className="mt-5 grid grid-cols-3 gap-3">
+              {actions.map((action) => (
+                <button key={action} className="rounded-xl border border-slate-800 bg-slate-950 p-4 text-left text-sm hover:border-slate-600">
+                  {action}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-slate-800 bg-slate-900 p-6">
+            <div className="flex items-center gap-2">
+              <ShieldCheck className="h-5 w-5" />
+              <h2 className="text-lg font-semibold">Status</h2>
+            </div>
+            <div className="mt-5 space-y-4 text-sm">
+              <div className="flex justify-between"><span className="text-slate-400">Cluster</span><span>Connected</span></div>
+              <div className="flex justify-between"><span className="text-slate-400">Policy</span><span>Local only</span></div>
+              <div className="flex justify-between"><span className="text-slate-400">Ingress</span><span>Disabled</span></div>
+              <div className="flex justify-between"><span className="text-slate-400">Audit</span><span>Pending</span></div>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-8 rounded-2xl border border-slate-800 bg-slate-900 p-6">
+          <h2 className="text-lg font-semibold">Target Runtime</h2>
+          <pre className="mt-4 overflow-auto rounded-xl bg-slate-950 p-4 text-sm text-slate-300">{`Console API → Kubernetes API → k3s → Agent workloads`}</pre>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/internal-agent-console/apps/web/next.config.js
+++ b/internal-agent-console/apps/web/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+module.exports = nextConfig;

--- a/internal-agent-console/apps/web/package.json
+++ b/internal-agent-console/apps/web/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@agennext/internal-agent-console-web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "lucide-react": "latest"
+  },
+  "devDependencies": {
+    "@types/node": "latest",
+    "@types/react": "latest",
+    "@types/react-dom": "latest",
+    "typescript": "latest",
+    "tailwindcss": "latest",
+    "postcss": "latest",
+    "autoprefixer": "latest",
+    "eslint": "latest",
+    "eslint-config-next": "latest"
+  }
+}

--- a/internal-agent-console/apps/web/tailwind.config.ts
+++ b/internal-agent-console/apps/web/tailwind.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+
+export default config;

--- a/internal-agent-console/apps/web/tsconfig.json
+++ b/internal-agent-console/apps/web/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/internal-agent-console/charts/agent-console/Chart.yaml
+++ b/internal-agent-console/charts/agent-console/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: agent-console
+description: Internal hPanel-style AGenNext console for k3s operations
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/internal-agent-console/charts/agent-console/templates/api.yaml
+++ b/internal-agent-console/charts/agent-console/templates/api.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent-console-api
+  labels:
+    app.kubernetes.io/name: agent-console-api
+spec:
+  replicas: {{ .Values.api.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: agent-console-api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: agent-console-api
+    spec:
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      containers:
+        - name: api
+          image: {{ .Values.api.image }}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: {{ .Values.api.port }}
+          env:
+            - name: AGENT_CONSOLE_MODE
+              value: internal-only
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: agent-console-api
+spec:
+  selector:
+    app.kubernetes.io/name: agent-console-api
+  ports:
+    - name: http
+      port: {{ .Values.api.port }}
+      targetPort: {{ .Values.api.port }}

--- a/internal-agent-console/charts/agent-console/templates/rbac.yaml
+++ b/internal-agent-console/charts/agent-console/templates/rbac.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: agent-console-operator
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces", "pods", "pods/log", "services", "configmaps", "secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: agent-console-operator
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: agent-console-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/internal-agent-console/charts/agent-console/templates/serviceaccount.yaml
+++ b/internal-agent-console/charts/agent-console/templates/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  labels:
+    app.kubernetes.io/name: agent-console

--- a/internal-agent-console/charts/agent-console/templates/web.yaml
+++ b/internal-agent-console/charts/agent-console/templates/web.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent-console-web
+  labels:
+    app.kubernetes.io/name: agent-console-web
+spec:
+  replicas: {{ .Values.web.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: agent-console-web
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: agent-console-web
+    spec:
+      containers:
+        - name: web
+          image: {{ .Values.web.image }}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: {{ .Values.web.port }}
+          env:
+            - name: NEXT_PUBLIC_API_BASE_URL
+              value: http://agent-console-api:{{ .Values.api.port }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: agent-console-web
+spec:
+  selector:
+    app.kubernetes.io/name: agent-console-web
+  ports:
+    - name: http
+      port: {{ .Values.web.port }}
+      targetPort: {{ .Values.web.port }}

--- a/internal-agent-console/charts/agent-console/values.yaml
+++ b/internal-agent-console/charts/agent-console/values.yaml
@@ -1,0 +1,19 @@
+web:
+  image: ghcr.io/agennext/internal-agent-console-web:latest
+  replicas: 1
+  port: 3000
+
+api:
+  image: ghcr.io/agennext/internal-agent-console-api:latest
+  replicas: 1
+  port: 8080
+
+serviceAccount:
+  create: true
+  name: agent-console
+
+ingress:
+  enabled: false
+
+rbac:
+  managedNamespaceLabel: agennext.io/managed-by=internal-agent-console

--- a/internal-agent-console/docs/architecture.md
+++ b/internal-agent-console/docs/architecture.md
@@ -1,0 +1,113 @@
+# Internal Agent Console Architecture
+
+## Goal
+
+Build an hPanel-style internal console for AGenNext operations.
+
+The console should hide Kubernetes from daily operators while keeping Kubernetes as the source of truth.
+
+## Control Plane Shape
+
+```text
+Browser
+  ↓
+Next.js Console
+  ↓
+Spring Boot API
+  ↓
+Kubernetes Java Client
+  ↓
+k3s API Server
+  ↓
+Deployments / Services / Jobs / Secrets / ConfigMaps
+```
+
+## Why Not Crossplane First
+
+Crossplane is useful when AGenNext becomes a platform API for many internal/external teams. For the immediate internal use case, it adds extra layers before the basic operations loop is stable.
+
+Start direct:
+
+```text
+Console API → Kubernetes API
+```
+
+Add Crossplane later only for infrastructure composition such as DNS, cloud databases, VPS, object storage, and external provider resources.
+
+## Core Objects
+
+### Workspace
+
+Maps to Kubernetes namespace.
+
+```text
+Workspace → Namespace
+```
+
+### Agent
+
+Maps to Kubernetes deployment unit.
+
+```text
+Agent → Deployment + Service + ConfigMap + Secret refs
+```
+
+### Secret
+
+Maps to Kubernetes secret.
+
+```text
+Secret → Kubernetes Secret
+```
+
+### Deployment
+
+Read from Kubernetes workloads.
+
+```text
+Deployment → apps/v1 Deployment status
+```
+
+### Logs
+
+Read from Kubernetes pods.
+
+```text
+Logs → Pod logs
+```
+
+## Minimal RBAC
+
+The console service account should initially operate only in namespaces labeled:
+
+```yaml
+agennext.io/managed-by: internal-agent-console
+```
+
+## API Endpoints
+
+```http
+GET    /api/dashboard
+GET    /api/workspaces
+POST   /api/workspaces
+DELETE /api/workspaces/{name}
+GET    /api/agents
+POST   /api/agents
+DELETE /api/agents/{workspace}/{name}
+POST   /api/agents/{workspace}/{name}/restart
+GET    /api/logs/{workspace}/{pod}
+GET    /api/secrets
+POST   /api/secrets
+```
+
+## First Deployment Rule
+
+Do not expose public ingress by default.
+
+Use local cluster access first:
+
+```bash
+kubectl port-forward svc/agent-console-web 3000:3000 -n agent-console
+```
+
+Public exposure should be added only after auth and policy are active.

--- a/internal-agent-console/examples/agent-request.json
+++ b/internal-agent-console/examples/agent-request.json
@@ -1,0 +1,6 @@
+{
+  "name": "research-agent",
+  "workspace": "research",
+  "image": "ghcr.io/agennext/research-agent:latest",
+  "replicas": 1
+}

--- a/internal-agent-console/examples/workspace-request.json
+++ b/internal-agent-console/examples/workspace-request.json
@@ -1,0 +1,4 @@
+{
+  "name": "research",
+  "description": "Internal research workspace"
+}


### PR DESCRIPTION
This PR is now intentionally superseded.

The internal hPanel-style console should live in a dedicated repository named AGenNext/Agent-Console, not inside Agent-Platform.

The branch remains useful as bootstrap source material, but it should not be merged into main.

Tracking issue: #40

Final structure:

Agent-Platform owns platform contracts, architecture, standards, and references.

Agent-Console owns the internal console UI, API, Kubernetes client integration, Helm chart, CI, and releases.