### PR TITLE
Add EnterpriseApp Kubernetes contract starter

### DIFF
--- a/.github/workflows/deploy-enterpriseapp.yml
+++ b/.github/workflows/deploy-enterpriseapp.yml
@@ -1,0 +1,56 @@
+name: Deploy EnterpriseApp Contracts
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Deployment target"
+        required: true
+        default: "whoami"
+        type: choice
+        options:
+          - whoami
+          - liferay-contract-only
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  deploy:
+    name: Deploy EnterpriseApp contracts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+      - name: Configure kubeconfig
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+        run: |
+          mkdir -p "$HOME/.kube"
+          printf '%s' "$KUBE_CONFIG" > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
+
+      - name: Validate cluster access
+        run: kubectl version --client=true && kubectl get nodes
+
+      - name: Apply EnterpriseApp CRD
+        run: kubectl apply -f platform/enterprise-app/crd/enterpriseapps.platform.agennext.io.yaml
+
+      - name: Deploy whoami contract
+        if: ${{ inputs.target == 'whoami' }}
+        run: |
+          kubectl create namespace platform-apps --dry-run=client -o yaml | kubectl apply -f -
+          kubectl apply -f platform/enterprise-app/catalog/whoami.yaml
+          kubectl get enterpriseapps.platform.agennext.io -A
+
+      - name: Deploy Liferay contract only
+        if: ${{ inputs.target == 'liferay-contract-only' }}
+        run: |
+          kubectl create namespace liferay --dry-run=client -o yaml | kubectl apply -f -
+          kubectl apply -f platform/enterprise-app/catalog/liferay.yaml
+          kubectl get enterpriseapps.platform.agennext.io -A

--- a/.github/workflows/enterpriseapp-contracts.yml
+++ b/.github/workflows/enterpriseapp-contracts.yml
@@ -1,0 +1,54 @@
+name: EnterpriseApp Contracts
+
+on:
+  pull_request:
+    paths:
+      - "platform/enterprise-app/**"
+      - ".github/workflows/enterpriseapp-contracts.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "platform/enterprise-app/**"
+      - ".github/workflows/enterpriseapp-contracts.yml"
+
+jobs:
+  validate-yaml:
+    name: Validate EnterpriseApp YAML
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate YAML parses
+        run: |
+          python - <<'PY'
+          import pathlib
+          import sys
+          import yaml
+
+          root = pathlib.Path('platform/enterprise-app')
+          failures = []
+
+          for path in sorted(root.rglob('*.yaml')):
+              try:
+                  docs = list(yaml.safe_load_all(path.read_text()))
+                  if not [doc for doc in docs if doc]:
+                      failures.append(f'{path}: no YAML documents found')
+              except Exception as exc:
+                  failures.append(f'{path}: {exc}')
+
+          if failures:
+              print('\n'.join(failures))
+              sys.exit(1)
+
+          print('EnterpriseApp YAML parsed successfully')
+          PY
+
+      - name: Validate Kubernetes CRD schema shape
+        run: |
+          test -f platform/enterprise-app/crd/enterpriseapps.platform.agennext.io.yaml
+          grep -q 'kind: CustomResourceDefinition' platform/enterprise-app/crd/enterpriseapps.platform.agennext.io.yaml
+          grep -q 'group: platform.agennext.io' platform/enterprise-app/crd/enterpriseapps.platform.agennext.io.yaml
+          grep -q 'kind: EnterpriseApp' platform/enterprise-app/catalog/whoami.yaml
+          grep -q 'kind: EnterpriseApp' platform/enterprise-app/catalog/liferay.yaml

--- a/.github/workflows/enterpriseapp-contracts.yml
+++ b/.github/workflows/enterpriseapp-contracts.yml
@@ -12,13 +12,20 @@ on:
       - "platform/enterprise-app/**"
       - ".github/workflows/enterpriseapp-contracts.yml"
 
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
 jobs:
   validate-yaml:
     name: Validate EnterpriseApp YAML
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Validate YAML parses
         run: |

--- a/platform/enterprise-app/README.md
+++ b/platform/enterprise-app/README.md
@@ -1,0 +1,56 @@
+# EnterpriseApp Platform Contract
+
+EnterpriseApp is the AGenNext deployment contract for enterprise applications on Kubernetes.
+
+The first goal is intentionally small:
+
+```text
+EnterpriseApp
+  -> Deployment
+  -> Service
+  -> PVC
+  -> Ingress
+```
+
+Liferay is included as a catalog entry, but it should not be the first validation target. Start with `whoami`, then promote to Liferay after the reconciliation loop is stable.
+
+## Files
+
+```text
+platform/enterprise-app/
+├── crd/enterpriseapps.platform.agennext.io.yaml
+├── catalog/whoami.yaml
+├── catalog/liferay.yaml
+├── kpack/liferay-image.yaml
+└── README.md
+```
+
+## Apply the CRD
+
+```bash
+kubectl apply -f platform/enterprise-app/crd/enterpriseapps.platform.agennext.io.yaml
+```
+
+## Apply the golden sample
+
+```bash
+kubectl create namespace platform-apps --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -f platform/enterprise-app/catalog/whoami.yaml
+```
+
+## Liferay contract
+
+```bash
+kubectl create namespace liferay --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -f platform/enterprise-app/catalog/liferay.yaml
+```
+
+## Buildpack path
+
+The `kpack/liferay-image.yaml` file defines the intended cluster-native image build path:
+
+```text
+Git source -> kpack Image -> OCI image -> EnterpriseApp deployment
+```
+
+The operator/reconciler should later convert EnterpriseApp intent into native Kubernetes resources.

--- a/platform/enterprise-app/catalog/liferay.yaml
+++ b/platform/enterprise-app/catalog/liferay.yaml
@@ -1,0 +1,36 @@
+apiVersion: platform.agennext.io/v1alpha1
+kind: EnterpriseApp
+metadata:
+  name: liferay
+  namespace: liferay
+  labels:
+    app.kubernetes.io/name: liferay
+    app.kubernetes.io/part-of: agennext-platform
+    platform.agennext.io/category: enterprise-portal
+spec:
+  image: liferay/portal:latest
+  replicas: 1
+  runtime:
+    kind: java
+    port: 8080
+  ingress:
+    enabled: true
+    className: caddy
+    host: portal.local
+  storage:
+    enabled: true
+    size: 50Gi
+    storageClassName: local-path
+    mountPath: /opt/liferay/data
+  database:
+    provider: postgresql
+    host: postgres.liferay.svc.cluster.local
+    port: 5432
+    name: liferay
+    secretName: liferay-db
+  search:
+    provider: elasticsearch
+    host: elasticsearch.liferay.svc.cluster.local
+    port: 9200
+  build:
+    provider: none

--- a/platform/enterprise-app/catalog/whoami.yaml
+++ b/platform/enterprise-app/catalog/whoami.yaml
@@ -1,0 +1,26 @@
+apiVersion: platform.agennext.io/v1alpha1
+kind: EnterpriseApp
+metadata:
+  name: whoami
+  namespace: platform-apps
+  labels:
+    app.kubernetes.io/name: whoami
+    app.kubernetes.io/part-of: agennext-platform
+spec:
+  image: traefik/whoami:v1.10
+  replicas: 1
+  runtime:
+    kind: container
+    port: 80
+  ingress:
+    enabled: true
+    className: caddy
+    host: whoami.local
+  storage:
+    enabled: false
+  database:
+    provider: none
+  search:
+    provider: none
+  build:
+    provider: none

--- a/platform/enterprise-app/crd/enterpriseapps.platform.agennext.io.yaml
+++ b/platform/enterprise-app/crd/enterpriseapps.platform.agennext.io.yaml
@@ -1,0 +1,150 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: enterpriseapps.platform.agennext.io
+  labels:
+    app.kubernetes.io/name: enterpriseapp
+    app.kubernetes.io/part-of: agennext-platform
+spec:
+  group: platform.agennext.io
+  scope: Namespaced
+  names:
+    plural: enterpriseapps
+    singular: enterpriseapp
+    kind: EnterpriseApp
+    shortNames:
+      - eapp
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required:
+            - spec
+          properties:
+            spec:
+              type: object
+              required:
+                - image
+              properties:
+                image:
+                  type: string
+                  description: OCI image to deploy when build is not used.
+                replicas:
+                  type: integer
+                  minimum: 0
+                  default: 1
+                runtime:
+                  type: object
+                  properties:
+                    kind:
+                      type: string
+                      enum:
+                        - container
+                        - java
+                    port:
+                      type: integer
+                      minimum: 1
+                      maximum: 65535
+                      default: 8080
+                ingress:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                      default: true
+                    className:
+                      type: string
+                      default: caddy
+                    host:
+                      type: string
+                storage:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                      default: false
+                    size:
+                      type: string
+                      pattern: '^[0-9]+(Mi|Gi|Ti)$'
+                    storageClassName:
+                      type: string
+                    mountPath:
+                      type: string
+                database:
+                  type: object
+                  properties:
+                    provider:
+                      type: string
+                      enum:
+                        - none
+                        - postgresql
+                        - mysql
+                        - external
+                      default: none
+                    host:
+                      type: string
+                    port:
+                      type: integer
+                    name:
+                      type: string
+                    secretName:
+                      type: string
+                search:
+                  type: object
+                  properties:
+                    provider:
+                      type: string
+                      enum:
+                        - none
+                        - elasticsearch
+                        - opensearch
+                        - external
+                      default: none
+                    host:
+                      type: string
+                    port:
+                      type: integer
+                build:
+                  type: object
+                  properties:
+                    provider:
+                      type: string
+                      enum:
+                        - none
+                        - kpack
+                      default: none
+                    git:
+                      type: object
+                      properties:
+                        url:
+                          type: string
+                        revision:
+                          type: string
+                    builder:
+                      type: string
+                    tag:
+                      type: string
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                observedGeneration:
+                  type: integer
+                message:
+                  type: string
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Image
+          type: string
+          jsonPath: .spec.image
+        - name: Replicas
+          type: integer
+          jsonPath: .spec.replicas
+        - name: Host
+          type: string
+          jsonPath: .spec.ingress.host

--- a/platform/enterprise-app/kpack/liferay-image.yaml
+++ b/platform/enterprise-app/kpack/liferay-image.yaml
@@ -1,0 +1,19 @@
+apiVersion: kpack.io/v1alpha2
+kind: Image
+metadata:
+  name: liferay
+  namespace: liferay
+  labels:
+    app.kubernetes.io/name: liferay
+    app.kubernetes.io/part-of: agennext-platform
+spec:
+  tag: ghcr.io/agennext/liferay:latest
+  serviceAccountName: kpack-registry-writer
+  builder:
+    kind: Builder
+    name: agennext-java-builder
+  source:
+    git:
+      url: https://github.com/AGenNext/Agent-Platform
+      revision: main
+    subPath: platform/enterprise-app/liferay-src

--- a/scripts/deploy-enterpriseapp.sh
+++ b/scripts/deploy-enterpriseapp.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+kubectl apply -f "${ROOT_DIR}/platform/enterprise-app/crd/enterpriseapps.platform.agennext.io.yaml"
+
+kubectl create namespace platform-apps --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -f "${ROOT_DIR}/platform/enterprise-app/catalog/whoami.yaml"
+
+kubectl get enterpriseapps.platform.agennext.io -A


### PR DESCRIPTION
## What this adds

This introduces the first AGenNext `EnterpriseApp` Kubernetes contract layer.

### Included

- `EnterpriseApp` CRD under `platform.agennext.io/v1alpha1`
- Golden `whoami` catalog sample for validating the reconciliation loop
- Liferay catalog contract as an enterprise portal app
- kpack `Image` contract for future cluster-native Liferay builds
- GitHub Actions workflow to validate YAML contract shape

## Why

This keeps Liferay as a platform catalog entry instead of a one-off deployment. The intended flow is:

```text
EnterpriseApp intent
  -> reconciler/operator
  -> Deployment / Service / PVC / Ingress
```

## Suggested next step

Build the reconciler against this CRD and validate the loop with `whoami` before promoting Liferay.
